### PR TITLE
feat/#15: 회원가입 후 초대 수락, 로그인 로직 리팩토링

### DIFF
--- a/src/main/java/com/haru/api/user/application/port/in/UserCommandUseCase.java
+++ b/src/main/java/com/haru/api/user/application/port/in/UserCommandUseCase.java
@@ -24,5 +24,5 @@ public interface UserCommandUseCase {
 
     UserResponseDTO.CheckOriginalPasswordResponse checkOriginalPassword(UserRequestDTO.CheckOriginalPasswordRequest request, User user);
 
-    UserResponseDTO.LoginResponse signupAndLoginAndInviteAccept(UserRequestDTO.SignUpRequest request, String token);
+    User createUser(UserRequestDTO.SignUpRequest request);
 }

--- a/src/main/java/com/haru/api/user/application/port/in/UserSignUpWorkflowUseCase.java
+++ b/src/main/java/com/haru/api/user/application/port/in/UserSignUpWorkflowUseCase.java
@@ -1,0 +1,10 @@
+package com.haru.api.user.application.port.in;
+
+import com.haru.api.user.presentation.dto.UserRequestDTO;
+import com.haru.api.user.presentation.dto.UserResponseDTO;
+
+public interface UserSignUpWorkflowUseCase {
+
+    UserResponseDTO.LoginResponse signUpAndLogin(UserRequestDTO.SignUpRequest request, String token);
+
+}

--- a/src/main/java/com/haru/api/user/application/service/UserCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/user/application/service/UserCommandUseCaseImpl.java
@@ -48,21 +48,14 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
     @Override
     public UserResponseDTO.User signUp(UserRequestDTO.SignUpRequest request, String token) {
 
-        String password = passwordEncoder.encode(request.getPassword());
+        // 유저 생성 및 저장
+        User createdUser = createUser(request);
 
-        // 이메일 중복 확인
-        Optional<User> foundUser = userRepository.findByEmail(request.getEmail());
-
-        if (foundUser.isPresent())
-            throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXISTS);
-
-        User user = UserConverter.toUsers(request, password);
-        userRepository.save(user);
-
+        // 초대 토큰이 있는 경우, 초대 수락 로직 호출
         if (token != null)
-            workspaceCommandUseCase.acceptInvite(token, user);
+            workspaceCommandUseCase.acceptInvite(token, createdUser);
 
-        return UserConverter.toUserDTO(user);
+        return UserConverter.toUserDTO(createdUser);
     }
 
     @Override
@@ -82,7 +75,7 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
     @Override
     public UserResponseDTO.RefreshResponse refresh(String refreshToken) {
         Long userId = SecurityUtil.getCurrentUserId();
-        String key = "users:" + userId.toString();
+        String key = "users:" + userId;
         String accessToken;
         String newRefreshToken;
 
@@ -104,11 +97,11 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
     public void logout(String accessToken) {
         // 로그아웃시킬 회원의 refresh token redis에서 삭제
         Long userId = SecurityUtil.getCurrentUserId();
-        String key = "users:" + userId.toString();
+        String key = "users:" + userId;
         redisTemplate.delete(key);
 
         // 로그아웃시킬 회원의 access token redis의 블랙리스트로 저장, 인가 처리시 블랙리스트 확인을 통해 로그아웃된 회원인지 확인함.
-        key = "blackList:" + userId.toString();
+        key = "blackList:" + userId;
         long tokenRemainTimeSecond = jwtUtils.tokenRemainTimeSecond(accessToken);
         redisTemplate.opsForValue().set(key, accessToken, tokenRemainTimeSecond, TimeUnit.SECONDS);
     }
@@ -173,29 +166,22 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
         return UserConverter.toCheckOriginalPassword(passwordEncoder.matches(request.getRequestPassword(), user.getPassword()));
     }
 
-    @Override
-    @Transactional
-    public UserResponseDTO.LoginResponse signupAndLoginAndInviteAccept(UserRequestDTO.SignUpRequest request, String token) {
 
+    @Override
+    public User createUser(UserRequestDTO.SignUpRequest request) {
+
+        // 이메일 중복 확인
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXISTS);
+        }
+
+        // 비밀번호 암호화
         String password = passwordEncoder.encode(request.getPassword());
 
-        User foundUser = userRepository.findByEmail(request.getEmail()).orElse(null);
+        // DTO를 User 도메인 객체로 변환
+        User user = UserConverter.toUsers(request, password);
 
-        if (foundUser != null) {
-            throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXISTS);
-        } else {
-
-            User user = UserConverter.toUsers(request, password);
-            userRepository.save(user);
-
-            if(token != null) {
-                workspaceCommandUseCase.acceptInvite(token, user);
-            }
-
-            return login(UserRequestDTO.LoginRequest.builder()
-                            .email(request.getEmail())
-                            .password(request.getPassword())
-                            .build());
-        }
+        // 데이터베이스에 저장
+        return userRepository.save(user);
     }
 }

--- a/src/main/java/com/haru/api/user/application/service/UserSignUpWorkflowUseCaseImpl.java
+++ b/src/main/java/com/haru/api/user/application/service/UserSignUpWorkflowUseCaseImpl.java
@@ -1,0 +1,38 @@
+package com.haru.api.user.application.service;
+
+import com.haru.api.user.application.port.in.UserCommandUseCase;
+import com.haru.api.user.application.port.in.UserSignUpWorkflowUseCase;
+import com.haru.api.user.domain.User;
+import com.haru.api.user.presentation.dto.UserRequestDTO;
+import com.haru.api.user.presentation.dto.UserResponseDTO;
+import com.haru.api.workspace.application.port.in.WorkspaceCommandUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserSignUpWorkflowUseCaseImpl implements UserSignUpWorkflowUseCase {
+
+    private final UserCommandUseCase userCommandUseCase;
+    private final WorkspaceCommandUseCase workspaceCommandUseCase;
+
+    @Override
+    public UserResponseDTO.LoginResponse signUpAndLogin(UserRequestDTO.SignUpRequest request, String token) {
+
+        // 회원가입
+        User createdUser = userCommandUseCase.createUser(request);
+
+        // 초대 토큰이 있는 경우, 초대 수락 로직 호출
+        if (token != null) {
+            workspaceCommandUseCase.acceptInvite(token, createdUser);
+        }
+
+        // 로그인
+        UserRequestDTO.LoginRequest loginRequest = UserRequestDTO.LoginRequest.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .build();
+
+        return userCommandUseCase.login(loginRequest);
+    }
+}

--- a/src/main/java/com/haru/api/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/haru/api/user/infrastructure/UserRepository.java
@@ -9,7 +9,11 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    List<User> findTop4UsersByEmailContainingIgnoreCase(String email); // <<< 이 부분은 내 브랜치에서 추가된 메서드
+
+    List<User> findTop4UsersByEmailContainingIgnoreCase(String email);
+
     Optional<User> findByEmail(String email);
+
     Optional<User> findByProviderId(String providerId);
+
 }

--- a/src/main/java/com/haru/api/user/presentation/UserController.java
+++ b/src/main/java/com/haru/api/user/presentation/UserController.java
@@ -1,5 +1,6 @@
 package com.haru.api.user.presentation;
 
+import com.haru.api.user.application.port.in.UserSignUpWorkflowUseCase;
 import com.haru.api.user.presentation.dto.UserRequestDTO;
 import com.haru.api.user.presentation.dto.UserResponseDTO;
 import com.haru.api.user.domain.User;
@@ -22,6 +23,7 @@ public class UserController {
 
     private final UserCommandUseCase userCommandUseCase;
     private final UserQueryUseCase userQueryUseCase;
+    private final UserSignUpWorkflowUseCase userSignUpWorkflowUseCase;
 
     @Operation(summary = "회원가입 [v1.0 (2025-08-05)]", description =
             "# [v1.0 (2025-08-05)](https://www.notion.so/2265da7802c580e8b883e3e4481fd61d?v=2265da7802c5816ab095000cc1ddadca&p=2265da7802c5819ca025d31fe9167842&pm=s)" +
@@ -32,10 +34,11 @@ public class UserController {
             @RequestBody @Valid UserRequestDTO.SignUpRequest request,
             @RequestParam(required = false) String token
     ) {
-
-        // 일반 회원가입
         return ApiResponse.onSuccess(
-                userCommandUseCase.signUp(request, token)
+                userCommandUseCase.signUp(
+                        request,
+                        token
+                )
         );
     }
 
@@ -48,7 +51,9 @@ public class UserController {
             @RequestBody @Valid UserRequestDTO.LoginRequest request
     ) {
         return ApiResponse.onSuccess(
-                userCommandUseCase.login(request)
+                userCommandUseCase.login(
+                        request
+                )
         );
     }
 
@@ -70,11 +75,13 @@ public class UserController {
                     "로그아웃 API 입니다. 로그아웃하고자 하는 유저의 Access Token을 header에 입력해주세요."
     )
     @DeleteMapping("/logout")
-    public ApiResponse<?> logout(
+    public ApiResponse<Object> logout(
             @RequestHeader("Authorization") String accessToken
     ) {
         userCommandUseCase.logout(accessToken);
-        return ApiResponse.onSuccess("");
+        return ApiResponse.onSuccess(
+                null
+        );
     }
 
     @Operation(summary = "회원 정보 조회", description =
@@ -85,9 +92,11 @@ public class UserController {
     public ApiResponse<UserResponseDTO.User> getUserInfo(
             @Parameter(hidden = true) @AuthUser User user
     ) {
-        UserResponseDTO.User userResponse = userQueryUseCase.getUserInfo(user);
-
-        return ApiResponse.onSuccess(userResponse);
+        return ApiResponse.onSuccess(
+                userQueryUseCase.getUserInfo(
+                        user
+                )
+        );
     }
 
     @Operation(summary = "회원 정보 수정", description =
@@ -99,9 +108,12 @@ public class UserController {
             @RequestBody @Valid UserRequestDTO.UserInfoUpdateRequest request,
             @Parameter(hidden = true) @AuthUser User user
     ) {
-        UserResponseDTO.User userResponse = userCommandUseCase.updateUserInfo(user, request);
-
-        return ApiResponse.onSuccess(userResponse);
+        return ApiResponse.onSuccess(
+                userCommandUseCase.updateUserInfo(
+                        user,
+                        request
+                )
+        );
     }
 
     @Operation(summary = "이메일로 회원 리스트 조회", description =
@@ -113,9 +125,12 @@ public class UserController {
             @RequestParam String email,
             @Parameter(hidden = true) @AuthUser User user
     ) {
-        List<UserResponseDTO.User> users = userQueryUseCase.getSimilarEmailUsers(user, email);
-
-        return ApiResponse.onSuccess(users);
+        return ApiResponse.onSuccess(
+                userQueryUseCase.getSimilarEmailUsers(
+                        user,
+                        email
+                )
+        );
     }
 
     @Operation(summary = "이메일 중복 검사 [v1.0 (2025-08-05)]", description =
@@ -142,7 +157,12 @@ public class UserController {
             @RequestBody UserRequestDTO.CheckOriginalPasswordRequest request,
             @Parameter(hidden = true) @AuthUser User user
     ) {
-        return ApiResponse.onSuccess(userCommandUseCase.checkOriginalPassword(request, user));
+        return ApiResponse.onSuccess(
+                userCommandUseCase.checkOriginalPassword(
+                        request,
+                        user
+                )
+        );
     }
 
     @Operation(summary = "회원가입 후 로그인", description =
@@ -154,8 +174,12 @@ public class UserController {
             @RequestBody @Valid UserRequestDTO.SignUpRequest request,
             @RequestParam(required = false) String token
     ) {
-        UserResponseDTO.LoginResponse response = userCommandUseCase.signupAndLoginAndInviteAccept(request, token);
 
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.onSuccess(
+                userSignUpWorkflowUseCase.signUpAndLogin(
+                        request,
+                        token
+                )
+        );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #15

## 📝작업 내용
> 회원가입 후 초대 수락, 로그인 로직 리팩토링

## 🔎코드 설명(스크린샷(선택))
- user를 생성하고 저장하는 createUser 메서드 추가
- 회원가입 로직에서 createUser 메서드를 사용하고, 초대 토큰이 있는 경우, 초대 수락 로직 호출하도록 구현
- 회원가입 후 로그인 로직은 UserSignUpWorkflowUseCase를 구현하여, 해당 use case에서 회원가입, 초대 수락, 로그인 로직 진행하도록 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X