### PR TITLE
feat/#17: UserPort 인터페이스 추가 및 user repository 관련 리팩토링

### DIFF
--- a/src/main/java/com/haru/api/global/argumentResolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/haru/api/global/argumentResolver/AuthUserArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.haru.api.global.argumentResolver;
 
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.user.domain.User;
-import com.haru.api.user.infrastructure.UserRepository;
 import com.haru.api.infra.security.jwt.SecurityUtil;
 import com.haru.api.global.annotation.AuthUser;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
@@ -18,7 +18,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final UserRepository userRepository;
+    private final UserPort userPort;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -40,7 +40,7 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             Long userId = SecurityUtil.getCurrentUserId();
 
             // 해당 유저가 존재하는지 확인하고, 존재하면 해당 user 객체 반환
-            return userRepository.findById(userId)
+            return userPort.findUserById(userId)
                     .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         }
     }

--- a/src/main/java/com/haru/api/global/interceptor/DocumentMemberAuthInterceptor.java
+++ b/src/main/java/com/haru/api/global/interceptor/DocumentMemberAuthInterceptor.java
@@ -1,11 +1,11 @@
 package com.haru.api.global.interceptor;
 
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.workspace.domain.enums.DocumentType;
 import com.haru.api.meeting.infrastructure.MeetingRepository;
 import com.haru.api.moodTracker.infrastructure.MoodTrackerRepository;
 import com.haru.api.snsEvent.infrastructure.SnsEventRepository;
 import com.haru.api.user.domain.User;
-import com.haru.api.user.infrastructure.UserRepository;
 import com.haru.api.infra.security.jwt.SecurityUtil;
 import com.haru.api.global.annotation.AuthDocument;
 import com.haru.api.global.annotation.AuthUser;
@@ -30,7 +30,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class DocumentMemberAuthInterceptor implements HandlerInterceptor {
 
-    private final UserRepository userRepository;
+    private final UserPort userPort;
 
     private final HashIdUtil hashIdUtil;
 
@@ -106,7 +106,7 @@ public class DocumentMemberAuthInterceptor implements HandlerInterceptor {
             };
 
             // 유저 조회
-            User foundUser = userRepository.findById(userId)
+            User foundUser = userPort.findUserById(userId)
                     .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
             // request에 attribute 저장

--- a/src/main/java/com/haru/api/global/interceptor/WorkspaceMemberAuthInterceptor.java
+++ b/src/main/java/com/haru/api/global/interceptor/WorkspaceMemberAuthInterceptor.java
@@ -1,7 +1,7 @@
 package com.haru.api.global.interceptor;
 
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.user.domain.User;
-import com.haru.api.user.infrastructure.UserRepository;
 import com.haru.api.infra.security.jwt.SecurityUtil;
 import com.haru.api.workspace.infrastructure.UserWorkspaceRepository;
 import com.haru.api.workspace.domain.Workspace;
@@ -26,7 +26,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WorkspaceMemberAuthInterceptor implements HandlerInterceptor {
 
-    private final UserRepository userRepository;
+    private final UserPort userPort;
 
     private final UserWorkspaceRepository userWorkspaceRepository;
 
@@ -72,7 +72,7 @@ public class WorkspaceMemberAuthInterceptor implements HandlerInterceptor {
             final Long userId = SecurityUtil.getCurrentUserId();
 
             // 유저 조회
-            User foundUser = userRepository.findById(userId)
+            User foundUser = userPort.findUserById(userId)
                     .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
             // 워크스페이스 조회

--- a/src/main/java/com/haru/api/infra/security/googleOauth2/CustomOauth2UserService.java
+++ b/src/main/java/com/haru/api/infra/security/googleOauth2/CustomOauth2UserService.java
@@ -1,8 +1,8 @@
 package com.haru.api.infra.security.googleOauth2;
 
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.user.domain.User;
 import com.haru.api.user.domain.enums.Status;
-import com.haru.api.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomOauth2UserService extends DefaultOAuth2UserService {
 
-    private final UserRepository userRepository;
+    private final UserPort userPort;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException { // 구글 OAuth서버와 Resource서버에서 유저 정보를 가져오는 메서드
@@ -23,7 +23,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         String email = (String) oAuth2User.getAttributes().get("email");
         String name = (String) oAuth2User.getAttributes().get("name");
         String profileImage = (String) oAuth2User.getAttributes().get("picture");
-        User foundUser = userRepository.findByProviderId(providerId).orElse(null);
+        User foundUser = userPort.findUserByProviderId(providerId).orElse(null);
         if (foundUser == null) {
             User newUser = User.builder()
                     .name(name)
@@ -32,7 +32,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
                     .profileImage(profileImage)
                     .providerId(providerId)
                     .build();
-            return new CustomOauth2UserDetails(userRepository.save(newUser), oAuth2User.getAttributes(), true);
+            return new CustomOauth2UserDetails(userPort.saveUser(newUser), oAuth2User.getAttributes(), true);
         } else{
             return new CustomOauth2UserDetails(foundUser, oAuth2User.getAttributes(), false);
         }

--- a/src/main/java/com/haru/api/infra/security/login/CustomUserDetailsService.java
+++ b/src/main/java/com/haru/api/infra/security/login/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.haru.api.infra.security.login;
 
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.user.domain.User;
-import com.haru.api.user.infrastructure.UserRepository;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +15,11 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements CustomDetailsService {
 
-    private final UserRepository userRepository;
+    private final UserPort userPort;
 
     @Override
     public UserDetails loadUserByUsername(String email, String password) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email)
+        User user = userPort.findUserByEmail(email)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_USERNAME_NOT_FOUND));
 
         org.springframework.security.core.userdetails.User securityUser = new org.springframework.security.core.userdetails.User(

--- a/src/main/java/com/haru/api/user/application/port/out/UserPort.java
+++ b/src/main/java/com/haru/api/user/application/port/out/UserPort.java
@@ -1,0 +1,32 @@
+package com.haru.api.user.application.port.out;
+
+import com.haru.api.user.domain.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserPort {
+
+    Optional<User> findUserById(Long id);
+
+    /**
+     * 특정 문자열과 비슷한 이메일을 가진 사용자를 검색한다.
+     */
+    List<User> searchSimilarEmailUsers(String emailKeyword);
+
+    /**
+     * 이메일로 사용자를 찾는다.
+     */
+    Optional<User> findUserByEmail(String email);
+
+    /**
+     * 소셜 로그인 제공자의 ID로 사용자를 찾는다.
+     */
+    Optional<User> findUserByProviderId(String providerId);
+
+    /**
+     * 사용자를 저장한다.
+     */
+    User saveUser(User user);
+
+}

--- a/src/main/java/com/haru/api/user/application/service/UserCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/user/application/service/UserCommandUseCaseImpl.java
@@ -1,12 +1,12 @@
 package com.haru.api.user.application.service;
 
 import com.haru.api.user.application.converter.UserConverter;
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.user.presentation.dto.UserRequestDTO;
 import com.haru.api.user.presentation.dto.UserResponseDTO;
 import com.haru.api.user.application.port.in.UserCommandUseCase;
 import com.haru.api.user.domain.User;
 import com.haru.api.user.domain.enums.EmailStatus;
-import com.haru.api.user.infrastructure.UserRepository;
 import com.haru.api.infra.security.jwt.JwtUtils;
 import com.haru.api.infra.security.jwt.SecurityUtil;
 import com.haru.api.workspace.application.port.in.WorkspaceCommandUseCase;
@@ -24,7 +24,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.haru.api.global.apiPayload.code.status.ErrorStatus.REFRESH_TOKEN_NOT_EQUAL;
@@ -38,8 +37,9 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
     @Value("${jwt.refresh-expiration}")
     private int refreshExpTime;
 
-    private final UserRepository userRepository;
+    private final UserPort userPort;
     private final WorkspaceCommandUseCase workspaceCommandUseCase;
+
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtUtils jwtUtils;
@@ -60,11 +60,14 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
 
     @Override
     public UserResponseDTO.LoginResponse login(UserRequestDTO.LoginRequest request) {
+
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
         // jwt토큰(access token, refresh token) 생성
-        User getUser = userRepository.findByEmail(authentication.getName()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        User getUser = userPort.findUserByEmail(authentication.getName())
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
         String key = "users:" + getUser.getId().toString();
         String accessToken = generateAccessToken(getUser.getId(), accessExpTime);
         String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
@@ -95,6 +98,7 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
 
     @Override
     public void logout(String accessToken) {
+
         // 로그아웃시킬 회원의 refresh token redis에서 삭제
         Long userId = SecurityUtil.getCurrentUserId();
         String key = "users:" + userId;
@@ -104,12 +108,14 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
         key = "blackList:" + userId;
         long tokenRemainTimeSecond = jwtUtils.tokenRemainTimeSecond(accessToken);
         redisTemplate.opsForValue().set(key, accessToken, tokenRemainTimeSecond, TimeUnit.SECONDS);
+
     }
 
 
     @Transactional
     @Override
     public UserResponseDTO.User updateUserInfo(User user, UserRequestDTO.UserInfoUpdateRequest request) {
+
         // 이름 수정 요청이 있을 경우
         if (request.getName() != null && !request.getName().trim().isEmpty()) {
             user.updateName(request.getName());
@@ -117,40 +123,47 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
 
         // 비밀번호 수정 요청이 있을 경우
         if (request.getPassword() != null && !request.getPassword().trim().isEmpty()) {
-            // 1. 새로운 비밀번호가 이전 비밀번호와 동일한지 확인
+            // 새로운 비밀번호가 이전 비밀번호와 동일한지 확인
             if (passwordEncoder.matches(request.getPassword(), user.getPassword())) {
                 throw new MemberHandler(ErrorStatus.SAME_WITH_OLD_PASSWORD);
             }
 
-            // 2. 새로운 비밀번호로 업데이트
+            // 새로운 비밀번호로 업데이트
             user.updatePassword(passwordEncoder.encode(request.getPassword()));
         }
 
-        return UserConverter.toUserDTO(user);
+        return UserConverter.toUserDTO(userPort.saveUser(user));
     }
 
     @Override
     public String generateAccessToken(Long userId, int accessExpTime) {
+
         // 인증 완료 후 jwt토큰(accessToken) 생성
         Map<String, Object> valueMap = Map.of(
                 "userId", userId
         );
+
         return jwtUtils.generateToken(valueMap, accessExpTime);
     }
 
     @Override
     public String generateAndSaveRefreshToken(String key, int refreshExpTime) {
+
         // 인증 완료 후 jwt토큰(refreshToken) 생성
         String refreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
+
         redisTemplate.opsForValue().set(key, refreshToken, refreshExpTime, TimeUnit.SECONDS);
+
         return refreshToken;
     }
 
     @Override
     public UserResponseDTO.CheckEmailDuplicationResponse checkEmailDuplication(UserRequestDTO.CheckEmailDuplicationRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())
+
+        User user = userPort.findUserByEmail(request.getEmail())
                 .orElse(null);
-        if (user == null) {
+
+        if (user == null) { // 해당 이메일을 사용하고 있는 유저가 존재하지 않을 경우
             return UserResponseDTO.CheckEmailDuplicationResponse.builder()
                     .emailStatus(EmailStatus.AVAILABLE)
                     .build();
@@ -171,7 +184,7 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
     public User createUser(UserRequestDTO.SignUpRequest request) {
 
         // 이메일 중복 확인
-        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+        if (userPort.findUserByEmail(request.getEmail()).isPresent()) {
             throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXISTS);
         }
 
@@ -182,6 +195,6 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
         User user = UserConverter.toUsers(request, password);
 
         // 데이터베이스에 저장
-        return userRepository.save(user);
+        return userPort.saveUser(user);
     }
 }

--- a/src/main/java/com/haru/api/user/application/service/UserQueryUseCaseImpl.java
+++ b/src/main/java/com/haru/api/user/application/service/UserQueryUseCaseImpl.java
@@ -1,10 +1,10 @@
 package com.haru.api.user.application.service;
 
 import com.haru.api.user.application.converter.UserConverter;
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.user.presentation.dto.UserResponseDTO;
 import com.haru.api.user.application.port.in.UserQueryUseCase;
 import com.haru.api.user.domain.User;
-import com.haru.api.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UserQueryUseCaseImpl implements UserQueryUseCase {
 
-    private final UserRepository userRepository;
+    private final UserPort userPort;
 
     @Override
     public UserResponseDTO.User getUserInfo(User user) {
@@ -25,7 +25,7 @@ public class UserQueryUseCaseImpl implements UserQueryUseCase {
     @Override
     public List<UserResponseDTO.User> getSimilarEmailUsers(User user, String email) {
 
-        List<User> users = userRepository.findTop4UsersByEmailContainingIgnoreCase(email);
+        List<User> users = userPort.searchSimilarEmailUsers(email);
 
         return users.parallelStream()
                 .map(eachUser -> UserResponseDTO.User.builder()

--- a/src/main/java/com/haru/api/user/infrastructure/adapter/UserJpaRepository.java
+++ b/src/main/java/com/haru/api/user/infrastructure/adapter/UserJpaRepository.java
@@ -1,14 +1,12 @@
-package com.haru.api.user.infrastructure;
+package com.haru.api.user.infrastructure.adapter;
 
 import com.haru.api.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-@Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     List<User> findTop4UsersByEmailContainingIgnoreCase(String email);
 

--- a/src/main/java/com/haru/api/user/infrastructure/adapter/UserPersistenceAdapter.java
+++ b/src/main/java/com/haru/api/user/infrastructure/adapter/UserPersistenceAdapter.java
@@ -1,0 +1,41 @@
+package com.haru.api.user.infrastructure.adapter;
+
+import com.haru.api.user.application.port.out.UserPort;
+import com.haru.api.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class UserPersistenceAdapter implements UserPort {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public Optional<User> findUserById(Long id) {
+        return userJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<User> searchSimilarEmailUsers(String emailKeyword) {
+        return userJpaRepository.findTop4UsersByEmailContainingIgnoreCase(emailKeyword);
+    }
+
+    @Override
+    public Optional<User> findUserByEmail(String email) {
+        return userJpaRepository.findByEmail(email);
+    }
+
+    @Override
+    public Optional<User> findUserByProviderId(String providerId) {
+        return userJpaRepository.findByProviderId(providerId);
+    }
+
+    @Override
+    public User saveUser(User user) {
+        return userJpaRepository.save(user);
+    }
+}

--- a/src/main/java/com/haru/api/workspace/application/service/UserDocumentLastOpenedQueryUseCaseImpl.java
+++ b/src/main/java/com/haru/api/workspace/application/service/UserDocumentLastOpenedQueryUseCaseImpl.java
@@ -1,12 +1,12 @@
 package com.haru.api.workspace.application.service;
 
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.workspace.application.port.in.UserDocumentLastOpenedQueryUseCase;
 import com.haru.api.workspace.domain.Documentable;
 import com.haru.api.workspace.domain.UserDocumentId;
 import com.haru.api.workspace.domain.UserDocumentLastOpened;
 import com.haru.api.workspace.infrastructure.UserDocumentLastOpenedRepository;
 import com.haru.api.user.domain.User;
-import com.haru.api.user.infrastructure.UserRepository;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import com.haru.api.global.common.entity.TitleHolder;
@@ -26,7 +26,8 @@ import java.util.List;
 public class UserDocumentLastOpenedQueryUseCaseImpl implements UserDocumentLastOpenedQueryUseCase {
 
     private final UserDocumentLastOpenedRepository userDocumentLastOpenedRepository;
-    private final UserRepository userRepository;
+    //private final UserJpaRepository userJpaRepository;
+    private final UserPort userPort;
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -34,7 +35,7 @@ public class UserDocumentLastOpenedQueryUseCaseImpl implements UserDocumentLastO
 
         UserDocumentLastOpened record = userDocumentLastOpenedRepository.findById(userDocumentId)
                 .orElseGet(() -> {
-                    User foundUser = userRepository.findById(userDocumentId.getUserId())
+                    User foundUser = userPort.findUserById(userDocumentId.getUserId())
                             .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
                     return UserDocumentLastOpened.builder()
                             .id(userDocumentId)

--- a/src/main/java/com/haru/api/workspace/application/service/WorkspaceCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/workspace/application/service/WorkspaceCommandUseCaseImpl.java
@@ -1,5 +1,6 @@
 package com.haru.api.workspace.application.service;
 
+import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.workspace.application.converter.UserDocumentLastOpenedConverter;
 import com.haru.api.workspace.application.port.in.WorkspaceCommandUseCase;
 import com.haru.api.workspace.domain.Documentable;
@@ -9,7 +10,6 @@ import com.haru.api.meeting.infrastructure.MeetingRepository;
 import com.haru.api.moodTracker.infrastructure.MoodTrackerRepository;
 import com.haru.api.snsEvent.infrastructure.SnsEventRepository;
 import com.haru.api.user.domain.User;
-import com.haru.api.user.infrastructure.UserRepository;
 import com.haru.api.workspace.domain.enums.Auth;
 import com.haru.api.workspace.domain.UserWorkspace;
 import com.haru.api.workspace.infrastructure.UserWorkspaceRepository;
@@ -41,7 +41,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
 
-    private final UserRepository userRepository;
+    //private final UserJpaRepository userJpaRepository;
+    private final UserPort userPort;
     private final WorkspaceRepository workspaceRepository;
     private final UserWorkspaceRepository userWorkspaceRepository;
     private final WorkspaceInvitationRepository workspaceInvitationRepository;
@@ -130,7 +131,7 @@ public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
             throw new WorkspaceInvitationHandler(ErrorStatus.ALREADY_ACCEPTED);
 
         // 초대받은 이메일로 가입된 사용자가 있는지 확인
-        Optional<User> foundUser = userRepository.findByEmail(foundWorkspaceInvitation.getEmail());
+        Optional<User> foundUser = userPort.findUserByEmail(foundWorkspaceInvitation.getEmail());
 
         boolean isAlreadyRegistered = foundUser.isPresent();
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #17

## 📝작업 내용
> UserPort 인터페이스 추가 및 user repository 관련 리팩토링

## 🔎코드 설명(스크린샷(선택))
- UserPort 인터페이스를 정의하여 데이터를 어떻게 처리할 지 정의
- UserJpaRepository 유지 (DB에 접근하는 실제 기술)
- UserPersistenceAdapter를 통해 UserPort를 implement 하여 Port라는 약속을 이행하기 위해 JPA Repository라는 도구를 사용하는 연결자 역할
- 이를 통해 use case에서 repository를 직접 사용하는게 아니라 adapter라는 중간자를 통하여 접근하기 때문에, 특정 기술에 의존적이지 않게 수정 가능(확장성)

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X