### PR TITLE
feat/#19: createUser 테스트 코드 작성

### DIFF
--- a/src/main/java/com/haru/api/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/BaseErrorCode.java
@@ -5,4 +5,6 @@ public interface BaseErrorCode {
     ErrorReasonDTO getReason();
 
     ErrorReasonDTO getReasonHttpStatus();
+
+    String getMessage();
 }

--- a/src/main/java/com/haru/api/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/haru/api/global/apiPayload/exception/GeneralException.java
@@ -3,14 +3,17 @@ package com.haru.api.global.apiPayload.exception;
 
 import com.haru.api.global.apiPayload.code.BaseErrorCode;
 import com.haru.api.global.apiPayload.code.ErrorReasonDTO;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
-    private BaseErrorCode code;
+    private final BaseErrorCode code;
+
+    public GeneralException(BaseErrorCode code) {
+        super(code.getMessage());
+        this.code = code;
+    }
 
     public ErrorReasonDTO getErrorReason() {
         return this.code.getReason();

--- a/src/main/java/com/haru/api/user/application/port/out/UserPort.java
+++ b/src/main/java/com/haru/api/user/application/port/out/UserPort.java
@@ -29,4 +29,9 @@ public interface UserPort {
      */
     User saveUser(User user);
 
+    /**
+     * 이메일이 존재하는지 확인한다.
+     */
+    boolean existsUserByEmail(String email);
+
 }

--- a/src/main/java/com/haru/api/user/application/service/UserCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/user/application/service/UserCommandUseCaseImpl.java
@@ -184,17 +184,14 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
     public User createUser(UserRequestDTO.SignUpRequest request) {
 
         // 이메일 중복 확인
-        if (userPort.findUserByEmail(request.getEmail()).isPresent()) {
+        if (userPort.existsUserByEmail(request.getEmail())) {
             throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXISTS);
         }
 
-        // 비밀번호 암호화
         String password = passwordEncoder.encode(request.getPassword());
 
-        // DTO를 User 도메인 객체로 변환
         User user = UserConverter.toUsers(request, password);
 
-        // 데이터베이스에 저장
         return userPort.saveUser(user);
     }
 }

--- a/src/main/java/com/haru/api/user/infrastructure/adapter/UserJpaRepository.java
+++ b/src/main/java/com/haru/api/user/infrastructure/adapter/UserJpaRepository.java
@@ -14,4 +14,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderId(String providerId);
 
+    boolean existsByEmail(String email);
+
 }

--- a/src/main/java/com/haru/api/user/infrastructure/adapter/UserPersistenceAdapter.java
+++ b/src/main/java/com/haru/api/user/infrastructure/adapter/UserPersistenceAdapter.java
@@ -38,4 +38,9 @@ public class UserPersistenceAdapter implements UserPort {
     public User saveUser(User user) {
         return userJpaRepository.save(user);
     }
+
+    @Override
+    public boolean existsUserByEmail(String email) {
+        return userJpaRepository.existsByEmail(email);
+    }
 }

--- a/src/test/java/com/haru/api/user/application/service/UserCommandUseCaseImplTest.java
+++ b/src/test/java/com/haru/api/user/application/service/UserCommandUseCaseImplTest.java
@@ -1,0 +1,79 @@
+package com.haru.api.user.application.service;
+
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
+import com.haru.api.user.application.port.out.UserPort;
+import com.haru.api.user.domain.User;
+import com.haru.api.user.presentation.dto.UserRequestDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class UserCommandUseCaseImplTest {
+
+    @InjectMocks
+    private UserCommandUseCaseImpl userCommandUseCase;
+
+    @Mock
+    private UserPort userPort;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("유저 생성 및 저장 성공")
+    void createUser() {
+
+        // given
+        UserRequestDTO.SignUpRequest request = UserRequestDTO.SignUpRequest.builder()
+                .email("test@nate.com")
+                .password("test1234")
+                .name("testNickname")
+                .marketingAgreed(true)
+                .build();
+
+        given(userPort.existsUserByEmail(request.getEmail())).willReturn(false);
+        given(passwordEncoder.encode(request.getPassword())).willReturn("encodedPassword");
+        given(userPort.saveUser(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        User createdUser = userCommandUseCase.createUser(request);
+
+        // then
+        assertThat(createdUser.getEmail()).isEqualTo(request.getEmail());
+        assertThat(createdUser.getPassword()).isEqualTo("encodedPassword");
+
+        verify(userPort).saveUser(any(User.class));
+    }
+
+    @Test
+    @DisplayName("유저 생성 및 저장 실패 - 중복된 이메일")
+    void createUser_fail_when_duplicate_email() {
+
+        // given
+        UserRequestDTO.SignUpRequest request = UserRequestDTO.SignUpRequest.builder()
+                .email("test@nate.com")
+                .password("test1234")
+                .name("testNickname")
+                .marketingAgreed(true)
+                .build();
+
+        given(userPort.existsUserByEmail(request.getEmail())).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userCommandUseCase.createUser(request))
+                .isInstanceOf(MemberHandler.class)
+                .hasMessageContaining(ErrorStatus.MEMBER_ALREADY_EXISTS.getMessage());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #19

## 📝작업 내용
> createUser 테스트 코드 작성

## 🔎코드 설명(스크린샷(선택))
- GeneralException에서 에러 메시지를 RuntimeException에 넘기도록 생성자에 super(code.getMessage()) 추가
- 이메일 중복 확인 시, findUserByEmail 대신 existsUserByEmail 사용
- createUser 메서드에 대하여 성공, 실패 테스트 코드 작성

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X