### PR TITLE
feat/#22: 유저 인증/인가 로직 AuthPort로 책임 분리

### DIFF
--- a/src/main/java/com/haru/api/infra/security/googleOauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/haru/api/infra/security/googleOauth2/CustomOAuth2SuccessHandler.java
@@ -1,6 +1,6 @@
 package com.haru.api.infra.security.googleOauth2;
 
-import com.haru.api.user.application.port.in.UserCommandUseCase;
+import com.haru.api.infra.security.jwt.JwtUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +15,10 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    @Value("${jwt.access-expiration}")
-    private int accessExpTime;
-    @Value("${jwt.refresh-expiration}")
-    private int refreshExpTime;
     @Value("${google-login-frontend-url}")
     String baseUrl;
-    private final UserCommandUseCase userCommandUseCase;
+
+    private final JwtUtils jwtUtils;
 
     @Override
     public void onAuthenticationSuccess(
@@ -34,8 +31,8 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
         // 회원가입이든 로그인이든 똑같이 프론트엔드로 리다이렉트
         Long userId = userDetails.getUser().getId();
         String key = "users:" + userId.toString();
-        String accessToken = userCommandUseCase.generateAccessToken(userId, accessExpTime);
-        String refreshToken = userCommandUseCase.generateAndSaveRefreshToken(key, refreshExpTime);
+        String accessToken = jwtUtils.generateAccessToken(userId);
+        String refreshToken = jwtUtils.generateAndSaveRefreshToken(key);
         // 프론트엔드 URL로 리다이렉트 (query param 전달)
         redirectUrl.append(baseUrl)
                 .append("?status=success")

--- a/src/main/java/com/haru/api/infra/security/jwt/JwtUtils.java
+++ b/src/main/java/com/haru/api/infra/security/jwt/JwtUtils.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
@@ -26,6 +27,13 @@ public class JwtUtils {
 
     @Value("${jwt.secret}")
     public String secretKey;
+
+    @Value("${jwt.access-expiration}")
+    private int accessExpTime;
+
+    @Value("${jwt.refresh-expiration}")
+    private int refreshExpTime;
+
     private final RedisTemplate<String, String> redisTemplate;
 
     // 헤더에 "Bearer XXX" 형식으로 담겨온 토큰을 추출한다
@@ -148,5 +156,25 @@ public class JwtUtils {
                 throw new CustomJwtException(ErrorStatus.LOGOUT_USER);
             }
         }
+    }
+
+    public String generateAccessToken(Long userId) {
+
+        // 인증 완료 후 jwt토큰(accessToken) 생성
+        Map<String, Object> valueMap = Map.of(
+                "userId", userId
+        );
+
+        return generateToken(valueMap, accessExpTime);
+    }
+
+    public String generateAndSaveRefreshToken(String key) {
+
+        // 인증 완료 후 jwt토큰(refreshToken) 생성
+        String refreshToken = generateToken(Collections.emptyMap(), refreshExpTime);
+
+        redisTemplate.opsForValue().set(key, refreshToken, refreshExpTime, TimeUnit.SECONDS);
+
+        return refreshToken;
     }
 }

--- a/src/main/java/com/haru/api/user/application/port/in/UserCommandUseCase.java
+++ b/src/main/java/com/haru/api/user/application/port/in/UserCommandUseCase.java
@@ -16,10 +16,6 @@ public interface UserCommandUseCase {
 
     void logout(String accessToken);
 
-    String generateAccessToken(Long userId, int accessExpTime);
-
-    String generateAndSaveRefreshToken(String key, int refreshExpTime);
-
     UserResponseDTO.CheckEmailDuplicationResponse checkEmailDuplication(UserRequestDTO.CheckEmailDuplicationRequest request);
 
     UserResponseDTO.CheckOriginalPasswordResponse checkOriginalPassword(UserRequestDTO.CheckOriginalPasswordRequest request, User user);

--- a/src/main/java/com/haru/api/user/application/port/out/AuthPort.java
+++ b/src/main/java/com/haru/api/user/application/port/out/AuthPort.java
@@ -1,0 +1,13 @@
+package com.haru.api.user.application.port.out;
+
+import com.haru.api.user.presentation.dto.UserRequestDTO;
+import com.haru.api.user.presentation.dto.UserResponseDTO;
+
+public interface AuthPort {
+
+    UserResponseDTO.LoginResponse login(UserRequestDTO.LoginRequest request);
+
+    void logout(String accessToken);
+
+    UserResponseDTO.RefreshResponse refresh(String accessToken);
+}

--- a/src/main/java/com/haru/api/user/application/service/UserCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/user/application/service/UserCommandUseCaseImpl.java
@@ -1,49 +1,30 @@
 package com.haru.api.user.application.service;
 
 import com.haru.api.user.application.converter.UserConverter;
+import com.haru.api.user.application.port.out.AuthPort;
 import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.user.presentation.dto.UserRequestDTO;
 import com.haru.api.user.presentation.dto.UserResponseDTO;
 import com.haru.api.user.application.port.in.UserCommandUseCase;
 import com.haru.api.user.domain.User;
 import com.haru.api.user.domain.enums.EmailStatus;
-import com.haru.api.infra.security.jwt.JwtUtils;
-import com.haru.api.infra.security.jwt.SecurityUtil;
 import com.haru.api.workspace.application.port.in.WorkspaceCommandUseCase;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import static com.haru.api.global.apiPayload.code.status.ErrorStatus.REFRESH_TOKEN_NOT_EQUAL;
 
 @Service
 @RequiredArgsConstructor
 public class UserCommandUseCaseImpl implements UserCommandUseCase {
 
-    @Value("${jwt.access-expiration}")
-    private int accessExpTime;
-    @Value("${jwt.refresh-expiration}")
-    private int refreshExpTime;
-
     private final UserPort userPort;
+    private final AuthPort authPort;
     private final WorkspaceCommandUseCase workspaceCommandUseCase;
 
     private final PasswordEncoder passwordEncoder;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
-    private final JwtUtils jwtUtils;
-    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public UserResponseDTO.User signUp(UserRequestDTO.SignUpRequest request, String token) {
@@ -60,57 +41,8 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
 
     @Override
     public UserResponseDTO.LoginResponse login(UserRequestDTO.LoginRequest request) {
-
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-
-        // jwt토큰(access token, refresh token) 생성
-        User getUser = userPort.findUserByEmail(authentication.getName())
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
-        String key = "users:" + getUser.getId().toString();
-        String accessToken = generateAccessToken(getUser.getId(), accessExpTime);
-        String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-
-        return UserConverter.toLoginResponse(getUser, accessToken, refreshToken);
+        return authPort.login(request);
     }
-
-    @Override
-    public UserResponseDTO.RefreshResponse refresh(String refreshToken) {
-        Long userId = SecurityUtil.getCurrentUserId();
-        String key = "users:" + userId;
-        String accessToken;
-        String newRefreshToken;
-
-        // 전달된 refresh token과 redis의 refresh token비교
-        String getRefreshTokenFromRedis = redisTemplate.opsForValue().get(key);
-        System.out.println("userId: " + userId);
-        System.out.println("redis에서 가져온 refreshToken: " + getRefreshTokenFromRedis);
-        if (refreshToken.equals(getRefreshTokenFromRedis)) {
-            accessToken = generateAccessToken(userId, accessExpTime);
-            newRefreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
-        } else {
-            throw new MemberHandler(REFRESH_TOKEN_NOT_EQUAL);
-        }
-
-        return UserConverter.toRefreshResponse(userId, accessToken, newRefreshToken);
-    }
-
-    @Override
-    public void logout(String accessToken) {
-
-        // 로그아웃시킬 회원의 refresh token redis에서 삭제
-        Long userId = SecurityUtil.getCurrentUserId();
-        String key = "users:" + userId;
-        redisTemplate.delete(key);
-
-        // 로그아웃시킬 회원의 access token redis의 블랙리스트로 저장, 인가 처리시 블랙리스트 확인을 통해 로그아웃된 회원인지 확인함.
-        key = "blackList:" + userId;
-        long tokenRemainTimeSecond = jwtUtils.tokenRemainTimeSecond(accessToken);
-        redisTemplate.opsForValue().set(key, accessToken, tokenRemainTimeSecond, TimeUnit.SECONDS);
-
-    }
-
 
     @Transactional
     @Override
@@ -136,25 +68,13 @@ public class UserCommandUseCaseImpl implements UserCommandUseCase {
     }
 
     @Override
-    public String generateAccessToken(Long userId, int accessExpTime) {
-
-        // 인증 완료 후 jwt토큰(accessToken) 생성
-        Map<String, Object> valueMap = Map.of(
-                "userId", userId
-        );
-
-        return jwtUtils.generateToken(valueMap, accessExpTime);
+    public UserResponseDTO.RefreshResponse refresh(String refreshToken) {
+        return authPort.refresh(refreshToken);
     }
 
     @Override
-    public String generateAndSaveRefreshToken(String key, int refreshExpTime) {
-
-        // 인증 완료 후 jwt토큰(refreshToken) 생성
-        String refreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
-
-        redisTemplate.opsForValue().set(key, refreshToken, refreshExpTime, TimeUnit.SECONDS);
-
-        return refreshToken;
+    public void logout(String accessToken) {
+        authPort.logout(accessToken);
     }
 
     @Override

--- a/src/main/java/com/haru/api/user/infrastructure/adapter/AuthImpl.java
+++ b/src/main/java/com/haru/api/user/infrastructure/adapter/AuthImpl.java
@@ -1,0 +1,86 @@
+package com.haru.api.user.infrastructure.adapter;
+
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
+import com.haru.api.infra.security.jwt.JwtUtils;
+import com.haru.api.infra.security.jwt.SecurityUtil;
+import com.haru.api.user.application.converter.UserConverter;
+import com.haru.api.user.application.port.out.AuthPort;
+import com.haru.api.user.application.port.out.UserPort;
+import com.haru.api.user.domain.User;
+import com.haru.api.user.presentation.dto.UserRequestDTO;
+import com.haru.api.user.presentation.dto.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.haru.api.global.apiPayload.code.status.ErrorStatus.REFRESH_TOKEN_NOT_EQUAL;
+
+@Service
+@RequiredArgsConstructor
+public class AuthImpl implements AuthPort {
+
+    private final UserPort userPort;
+
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtUtils jwtUtils;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public UserResponseDTO.LoginResponse login(UserRequestDTO.LoginRequest request) {
+
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        // jwt토큰(access token, refresh token) 생성
+        User getUser = userPort.findUserByEmail(authentication.getName())
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        String key = "users:" + getUser.getId().toString();
+        String accessToken = jwtUtils.generateAccessToken(getUser.getId());
+        String refreshToken = jwtUtils.generateAndSaveRefreshToken(key);
+
+        return UserConverter.toLoginResponse(getUser, accessToken, refreshToken);
+    }
+
+    @Override
+    public void logout(String accessToken) {
+
+        // 로그아웃시킬 회원의 refresh token redis에서 삭제
+        Long userId = SecurityUtil.getCurrentUserId();
+        String key = "users:" + userId;
+        redisTemplate.delete(key);
+
+        // 로그아웃시킬 회원의 access token redis의 블랙리스트로 저장, 인가 처리시 블랙리스트 확인을 통해 로그아웃된 회원인지 확인함.
+        key = "blackList:" + userId;
+        long tokenRemainTimeSecond = jwtUtils.tokenRemainTimeSecond(accessToken);
+        redisTemplate.opsForValue().set(key, accessToken, tokenRemainTimeSecond, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public UserResponseDTO.RefreshResponse refresh(String refreshToken) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        String key = "users:" + userId;
+        String accessToken;
+        String newRefreshToken;
+
+        // 전달된 refresh token과 redis의 refresh token비교
+        String getRefreshTokenFromRedis = redisTemplate.opsForValue().get(key);
+        System.out.println("userId: " + userId);
+        System.out.println("redis에서 가져온 refreshToken: " + getRefreshTokenFromRedis);
+        if (refreshToken.equals(getRefreshTokenFromRedis)) {
+            accessToken = jwtUtils.generateAccessToken(userId);
+            newRefreshToken = jwtUtils.generateAndSaveRefreshToken(key);
+        } else {
+            throw new MemberHandler(REFRESH_TOKEN_NOT_EQUAL);
+        }
+
+        return UserConverter.toRefreshResponse(userId, accessToken, newRefreshToken);
+
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #22

## 📝작업 내용
> 유저 인증/인가 로직 AuthPort로 책임 분리

## 🔎코드 설명(스크린샷(선택))
- AuthPort로 login, logout, refresh 메서드를 옮기고, AuthImpl이 구현체
- generateAccessToken, generateRefreshToken 기능을 UserCommandUseCase에서 JwtUtils로 옮김으로써 책임 명확히 함
- UserCommandUseCase에서는 AuthPort를 주입받아서 사용하면서 인증/인가와 유저의 책임 분리가 이루어짐

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X