### PR TITLE
refactor/#49: workspace 리팩토링

### DIFF
--- a/src/main/java/com/haru/api/global/argumentResolver/AuthDocumentArgumentResolver.java
+++ b/src/main/java/com/haru/api/global/argumentResolver/AuthDocumentArgumentResolver.java
@@ -1,6 +1,6 @@
 package com.haru.api.global.argumentResolver;
 
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.enums.DocumentType;
 import com.haru.api.global.annotation.AuthDocument;
 import com.haru.api.global.documentFinder.DocumentFinder;

--- a/src/main/java/com/haru/api/global/aspect/DeleteDocumentAspect.java
+++ b/src/main/java/com/haru/api/global/aspect/DeleteDocumentAspect.java
@@ -1,7 +1,7 @@
 package com.haru.api.global.aspect;
 
-import com.haru.api.global.common.Documentable;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.shared_kernel.domain.Documentable;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeleteDocumentAspect {
 
-    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
 
     @AfterReturning("@annotation(com.haru.api.global.annotation.DeleteDocument)")
     public void afterDeleteDocument(JoinPoint joinPoint) {
@@ -33,7 +33,7 @@ public class DeleteDocumentAspect {
 
         // Documentable 객체를 토대로 서비스 로직 호출
         if (document != null) {
-            userDocumentLastOpenedQueryUseCase.deleteRecordsForWorkspaceUsers(document);
+            userDocumentLastOpenedCommandUseCase.deleteRecordsForWorkspaceUsers(document);
         }
     }
 }

--- a/src/main/java/com/haru/api/global/aspect/LastOpenedAspect.java
+++ b/src/main/java/com/haru/api/global/aspect/LastOpenedAspect.java
@@ -1,8 +1,8 @@
 package com.haru.api.global.aspect;
 
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.UserDocumentId;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import com.haru.api.user.domain.User;
 import com.haru.api.global.annotation.TrackLastOpened;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @Order(1)
 public class LastOpenedAspect {
 
-    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
 
     @Around("@annotation(trackLastOpened)")
     public Object trackLastOpened(ProceedingJoinPoint joinPoint, TrackLastOpened trackLastOpened) throws Throwable {
@@ -39,7 +39,7 @@ public class LastOpenedAspect {
 
             UserDocumentId userDocumentId = new UserDocumentId(user.getId(), document.getId(), document.getDocumentType());
 
-            userDocumentLastOpenedQueryUseCase.updateLastOpened(userDocumentId, workspaceId, title);
+            userDocumentLastOpenedCommandUseCase.updateLastOpened(userDocumentId, workspaceId, title);
         }
 
         return result;

--- a/src/main/java/com/haru/api/global/aspect/UpdateDocumentTitleAspect.java
+++ b/src/main/java/com/haru/api/global/aspect/UpdateDocumentTitleAspect.java
@@ -1,8 +1,8 @@
 package com.haru.api.global.aspect;
 
-import com.haru.api.global.common.Documentable;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
-import com.haru.api.global.common.entity.DocumentModifier;
+import com.haru.api.shared_kernel.domain.Documentable;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
+import com.haru.api.shared_kernel.domain.DocumentModifier;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UpdateDocumentTitleAspect {
 
-    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
 
     @AfterReturning("@annotation(com.haru.api.global.annotation.UpdateDocumentTitle)")
     public void afterTitleUpdate(JoinPoint joinPoint) {
@@ -36,7 +36,7 @@ public class UpdateDocumentTitleAspect {
 
         // document, titleHolder가 정상적으로 조회되면 last opened 테이블에서 해당 문서의 제목 수정
         if (document != null && documentModifier != null) {
-            userDocumentLastOpenedQueryUseCase.updateRecordsTitleAndThumbnailForWorkspaceUsers(document, documentModifier);
+            userDocumentLastOpenedCommandUseCase.updateRecordsTitleAndThumbnailForWorkspaceUsers(document, documentModifier);
         }
     }
 }

--- a/src/main/java/com/haru/api/meeting/application/service/MeetingCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/meeting/application/service/MeetingCommandUseCaseImpl.java
@@ -3,7 +3,7 @@ package com.haru.api.meeting.application.service;
 import com.haru.api.meeting.application.port.in.MeetingCommandUseCase;
 import com.haru.api.user.domain.UserDocumentLastOpened;
 import com.haru.api.user.infrastructure.jpa.UserDocumentLastOpenedJpaRepository;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import com.haru.api.meeting.application.converter.MeetingConverter;
 import com.haru.api.meeting.presentation.dto.MeetingRequestDTO;
 import com.haru.api.meeting.presentation.dto.MeetingResponseDTO;
@@ -58,7 +58,7 @@ public class MeetingCommandUseCaseImpl implements MeetingCommandUseCase {
     private final MeetingRepository meetingRepository;
     private final KeywordRepository keywordRepository;
     private final ChatGPTClient chatGPTClient;
-    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
     private final UserDocumentLastOpenedJpaRepository userDocumentLastOpenedJpaRepository;
     private final WebSocketSessionRegistry webSocketSessionRegistry;
     private final SpeechSegmentRepository speechSegmentRepository;
@@ -126,7 +126,7 @@ public class MeetingCommandUseCaseImpl implements MeetingCommandUseCase {
         // meeting 생성 시 워크스페이스에 속해있는 모든 유저에 대해
         // last opened 테이블에 마지막으로 연 시간은 null로하여 추가
         List<User> usersInWorkspace = userWorkspaceJpaRepository.findUsersByWorkspaceId(foundWorkspace.getId());
-        userDocumentLastOpenedQueryUseCase.createInitialRecordsForWorkspaceUsers(usersInWorkspace, savedMeeting);
+        userDocumentLastOpenedCommandUseCase.createInitialRecordsForWorkspaceUsers(usersInWorkspace, savedMeeting);
 
         return MeetingConverter.toCreateMeetingResponse(savedMeeting);
     }

--- a/src/main/java/com/haru/api/meeting/domain/Meeting.java
+++ b/src/main/java/com/haru/api/meeting/domain/Meeting.java
@@ -1,6 +1,6 @@
 package com.haru.api.meeting.domain;
 
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.enums.DocumentType;
 import com.haru.api.user.domain.User;
 import com.haru.api.workspace.domain.Workspace;

--- a/src/main/java/com/haru/api/meeting/presentation/dto/MeetingRequestDTO.java
+++ b/src/main/java/com/haru/api/meeting/presentation/dto/MeetingRequestDTO.java
@@ -1,7 +1,7 @@
 package com.haru.api.meeting.presentation.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.haru.api.global.common.entity.DocumentModifier;
+import com.haru.api.shared_kernel.domain.DocumentModifier;
 import com.haru.api.global.util.json.ToLongDeserializer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/haru/api/moodTracker/application/service/MoodTrackerCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/moodTracker/application/service/MoodTrackerCommandUseCaseImpl.java
@@ -5,7 +5,7 @@ import com.haru.api.moodTracker.application.port.in.MoodTrackerMailUseCase;
 import com.haru.api.moodTracker.application.port.in.MoodTrackerReportUseCase;
 import com.haru.api.moodTracker.domain.*;
 import com.haru.api.moodTracker.infrastructure.*;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import com.haru.api.moodTracker.application.converter.MoodTrackerConverter;
 import com.haru.api.moodTracker.presentation.dto.MoodTrackerRequestDTO;
 import com.haru.api.moodTracker.presentation.dto.MoodTrackerResponseDTO;
@@ -60,7 +60,7 @@ public class MoodTrackerCommandUseCaseImpl implements MoodTrackerCommandUseCase 
 
     private final HashIdUtil hashIdUtil;
 
-    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
     private final WorkspaceJpaRepository workspaceJpaRepository;
 
     /**
@@ -101,7 +101,7 @@ public class MoodTrackerCommandUseCaseImpl implements MoodTrackerCommandUseCase 
         // mood tracker 생성 시 워크스페이스에 속해있는 모든 유저에 대해
         // last opened 테이블에 마지막으로 연 시간은 null로하여 추가
         List<User> usersInWorkspace = userWorkspaceJpaRepository.findUsersByWorkspaceId(foundWorkspace.getId());
-        userDocumentLastOpenedQueryUseCase.createInitialRecordsForWorkspaceUsers(usersInWorkspace, savedMoodTracker);
+        userDocumentLastOpenedCommandUseCase.createInitialRecordsForWorkspaceUsers(usersInWorkspace, savedMoodTracker);
 
         return MoodTrackerConverter.toCreateResultDTO(moodTracker, hashIdUtil);
     }

--- a/src/main/java/com/haru/api/moodTracker/application/service/MoodTrackerQueryUseCaseImpl.java
+++ b/src/main/java/com/haru/api/moodTracker/application/service/MoodTrackerQueryUseCaseImpl.java
@@ -4,7 +4,7 @@ import com.haru.api.moodTracker.application.port.in.MoodTrackerQueryUseCase;
 import com.haru.api.moodTracker.infrastructure.MoodTrackerRepository;
 import com.haru.api.moodTracker.infrastructure.SurveyQuestionRepository;
 import com.haru.api.user.domain.UserDocumentId;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import com.haru.api.moodTracker.application.converter.MoodTrackerConverter;
 import com.haru.api.moodTracker.presentation.dto.MoodTrackerResponseDTO;
 import com.haru.api.moodTracker.domain.MoodTracker;
@@ -40,7 +40,7 @@ public class MoodTrackerQueryUseCaseImpl implements MoodTrackerQueryUseCase {
 
     private final SurveyQuestionRepository surveyQuestionRepository;
 
-    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
 
     @Override
     public MoodTrackerResponseDTO.PreviewList getPreviewList(User user, Workspace workspace) {
@@ -99,7 +99,7 @@ public class MoodTrackerQueryUseCaseImpl implements MoodTrackerQueryUseCase {
 
         UserDocumentId userDocumentId = new UserDocumentId(user.getId(), moodTracker.getId(), moodTracker.getDocumentType());
 
-        userDocumentLastOpenedQueryUseCase.updateLastOpened(userDocumentId, workspaceId, title);
+        userDocumentLastOpenedCommandUseCase.updateLastOpened(userDocumentId, workspaceId, title);
 
         // 권한 확인
         UserWorkspace userWorkspace = userWorkspaceJpaRepository.findByWorkspaceIdAndUserId(
@@ -138,7 +138,7 @@ public class MoodTrackerQueryUseCaseImpl implements MoodTrackerQueryUseCase {
 
         UserDocumentId userDocumentId = new UserDocumentId(user.getId(), moodTracker.getId(), moodTracker.getDocumentType());
 
-        userDocumentLastOpenedQueryUseCase.updateLastOpened(userDocumentId, workspaceId, title);
+        userDocumentLastOpenedCommandUseCase.updateLastOpened(userDocumentId, workspaceId, title);
 
         // 권한 확인
         UserWorkspace userWorkspace = userWorkspaceJpaRepository.findByWorkspaceIdAndUserId(

--- a/src/main/java/com/haru/api/moodTracker/application/service/MoodTrackerReportUseCaseImpl.java
+++ b/src/main/java/com/haru/api/moodTracker/application/service/MoodTrackerReportUseCaseImpl.java
@@ -3,7 +3,7 @@ package com.haru.api.moodTracker.application.service;
 import com.haru.api.moodTracker.application.port.in.MoodTrackerReportUseCase;
 import com.haru.api.moodTracker.domain.*;
 import com.haru.api.moodTracker.infrastructure.*;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import com.haru.api.moodTracker.presentation.dto.MoodTrackerRequestDTO;
 import com.haru.api.snsEvent.domain.enums.Format;
 import com.haru.api.user.domain.User;
@@ -48,7 +48,7 @@ public class MoodTrackerReportUseCaseImpl implements MoodTrackerReportUseCase {
     private final MultipleChoiceAnswerRepository multipleChoiceAnswerRepository;
     private final CheckboxChoiceAnswerRepository checkboxChoiceAnswerRepository;
     private final UserWorkspaceJpaRepository userWorkspaceJpaRepository;
-    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
 
     private final AmazonS3Manager amazonS3Manager;
     private final MarkdownFileUploader markdownFileUploader;
@@ -265,7 +265,7 @@ public class MoodTrackerReportUseCaseImpl implements MoodTrackerReportUseCase {
 
         // Mood Tracker 제목 수정 시 워크스페이스에 속해있는 모든 유저에 대해 썸네일 이미지 키 수정
         List<User> usersInWorkspace = userWorkspaceJpaRepository.findUsersByWorkspaceId(foundMoodTracker.getWorkspace().getId());
-        userDocumentLastOpenedQueryUseCase.updateRecordsTitleAndThumbnailForWorkspaceUsers(
+        userDocumentLastOpenedCommandUseCase.updateRecordsTitleAndThumbnailForWorkspaceUsers(
                 foundMoodTracker,
                 MoodTrackerRequestDTO.UpdateTitleRequest.builder().title(foundMoodTracker.getTitle()).build()
         );

--- a/src/main/java/com/haru/api/moodTracker/domain/MoodTracker.java
+++ b/src/main/java/com/haru/api/moodTracker/domain/MoodTracker.java
@@ -1,6 +1,6 @@
 package com.haru.api.moodTracker.domain;
 
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.enums.DocumentType;
 import com.haru.api.moodTracker.domain.enums.MoodTrackerVisibility;
 import com.haru.api.user.domain.User;

--- a/src/main/java/com/haru/api/moodTracker/presentation/MoodTrackerController.java
+++ b/src/main/java/com/haru/api/moodTracker/presentation/MoodTrackerController.java
@@ -12,7 +12,6 @@ import com.haru.api.global.annotation.AuthMoodTracker;
 import com.haru.api.global.annotation.AuthUser;
 import com.haru.api.global.annotation.AuthWorkspace;
 import com.haru.api.global.apiPayload.code.status.SuccessStatus;
-import com.haru.api.global.util.HashIdUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -28,12 +27,9 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class MoodTrackerController {
 
-    // DB 변경
     private final MoodTrackerCommandUseCase moodTrackerCommandUseCase;
 
-    // 읽기 전용
     private final MoodTrackerQueryUseCase moodTrackerQueryUseCase;
-    private final HashIdUtil hashIdUtil;
 
 
     @GetMapping("/workspaces/{workspaceId}")
@@ -77,16 +73,16 @@ public class MoodTrackerController {
 
     }
 
-    @PatchMapping("/{mood-tracker-hashed-Id}")
+    @PatchMapping("/{moodTrackerId}")
     @Operation(
             summary = "분위기 트래커 설문명 수정 API",
             description = "# [v1.0 (2025-07-26)](https://www.notion.so/22a5da7802c580fe80ece5981e90b03b) 해당 ID의 분위기 트래커 설문 제목(title)을 수정합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "분위기 트래커 ID (Path Variable)", required = true)
     })
     public ApiResponse<Void> updateMoodTrackerTitle(
-            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable(name = "moodTrackerId") String moodTrackerId,
             @RequestBody @Valid MoodTrackerRequestDTO.UpdateTitleRequest request,
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(hidden = true) @AuthMoodTracker MoodTracker moodTracker
@@ -98,7 +94,7 @@ public class MoodTrackerController {
 
     }
 
-    @DeleteMapping("/{mood-tracker-hashed-Id}")
+    @DeleteMapping("/{moodTrackerId}")
     @Operation(
             summary = "분위기 트래커 설문 삭제 API",
             description = "# [v1.0 (2025-07-26)](https://www.notion.so/2265da7802c58011aa54ea2c1818ef04) 해당 ID의 분위기 트래커 설문을 삭제합니다."
@@ -107,7 +103,7 @@ public class MoodTrackerController {
             @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
     })
     public ApiResponse<Void> deleteMoodTracker(
-            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable(name = "moodTrackerId") String moodTrackerId,
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(hidden = true) @AuthMoodTracker MoodTracker moodTracker
     ) {
@@ -118,16 +114,16 @@ public class MoodTrackerController {
 
     }
 
-    @PostMapping("/{mood-tracker-hashed-Id}/emails")
+    @PostMapping("/{moodTrackerId}/emails")
     @Operation(
             summary = "분위기 트래커 설문 링크 워크 스페이스 내의 팀원 email 전송 API",
             description = "# [v1.0 (2025-07-26)](https://www.notion.so/22a5da7802c580a799cec13c005824d7) 해당 ID의 분위기 트래커 설문 링크를 워크 스페이스 내의 유저에게 email로 전송합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
     })
     public ApiResponse<Void> sendMoodTrackerSurveyLink(
-            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable(name = "moodTrackerId") String moodTrackerId,
             @Parameter(hidden = true) @AuthMoodTracker MoodTracker moodTracker
     ) {
 
@@ -137,26 +133,26 @@ public class MoodTrackerController {
 
     }
 
-    @PostMapping("/{mood-tracker-hashed-Id}/answer")
+    @PostMapping("/{moodTrackerId}/answer")
     @Operation(
             summary = "분위기 트래커 설문 답변 제출 API (비인증)",
             description = "# [v1.2 (2025-08-19)](https://www.notion.so/2265da7802c580c58d36e73639e41291) 해당 ID의 분위기 트래커 설문 답변을 제출합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "분위기 트래커 ID (Path Variable)", required = true)
     })
     public  ApiResponse<Void> submitMoodTrackerSurveyAnswers(
-            @PathVariable("mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable("moodTrackerId") Long moodTrackerId,
             @Valid @RequestBody MoodTrackerRequestDTO.SurveyAnswerList request
     ) {
 
-        moodTrackerCommandUseCase.submitSurveyAnswers(hashIdUtil.decode(moodTrackerHashedId), request);
+        moodTrackerCommandUseCase.submitSurveyAnswers(moodTrackerId, request);
 
         return ApiResponse.of(SuccessStatus.MOOD_TRACKER_ANSWER_SUBMIT, null);
 
     }
 
-    @GetMapping("/{mood-tracker-hashed-Id}/bases")
+    @GetMapping("/{moodTrackerId}/bases")
     @Operation(
             summary = "분위기 트래커 설문 팀분위기 베이스 정보 조회 API (비인증)",
             description = "# [v1.1 (2025-08-19)](https://www.notion.so/2545da7802c580dd9742d971d3a4bc08?source=copy_link) 분위기 트래커(moodTrackerId)에 대한 베이스 정보를 조회합니다."
@@ -165,43 +161,43 @@ public class MoodTrackerController {
             @Parameter(name = "mood-tracker-hashed-Id", description = "분위기 트래커 ID (Hashed, Path Variable)", required = true)
     })
     public ApiResponse<MoodTrackerResponseDTO.BaseResult> getMoodTrackerBaseResult(
-            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId
+            @PathVariable(name = "moodTrackerId") Long moodTrackerId
     ) {
 
-        MoodTrackerResponseDTO.BaseResult result = moodTrackerQueryUseCase.getBaseResult(hashIdUtil.decode(moodTrackerHashedId));
+        MoodTrackerResponseDTO.BaseResult result = moodTrackerQueryUseCase.getBaseResult(moodTrackerId);
 
         return ApiResponse.onSuccess(result);
 
     }
 
-    @GetMapping("/{mood-tracker-hashed-Id}/questions")
+    @GetMapping("/{moodTrackerId}/questions")
     @Operation(
             summary = "분위기 트래커 설문 문항 조회 API (비인증)",
             description = "# [v1.3 (2025-08-19)](https://www.notion.so/2295da7802c580dbb88aee8687b69e32) 분위기 트래커(moodTrackerId)에 해당하는 설문 문항들을 조회합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "분위기 트래커 ID (Hashed, Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "분위기 트래커 ID (Path Variable)", required = true)
     })
     public ApiResponse<MoodTrackerResponseDTO.QuestionResult> getMoodTrackerQuestionResult(
-            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId
+            @PathVariable(name = "moodTrackerId") Long moodTrackerId
     ) {
 
-        MoodTrackerResponseDTO.QuestionResult result = moodTrackerQueryUseCase.getQuestionResult(hashIdUtil.decode(moodTrackerHashedId));
+        MoodTrackerResponseDTO.QuestionResult result = moodTrackerQueryUseCase.getQuestionResult(moodTrackerId);
 
         return ApiResponse.onSuccess(result);
 
     }
 
-    @GetMapping("/{mood-tracker-hashed-Id}/reports")
+    @GetMapping("/{moodTrackerId}/reports")
     @Operation(
             summary = "분위기 트래커 설문 팀분위기 리포트 조회 API + last opend 처리",
             description = "# [v1.2 (2025-08-05)](https://www.notion.so/2295da7802c580ba8401c449389e8f78) 분위기 트래커(moodTrackerId)에 대한 팀 전체 리포트를 조회합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "분위기 트래커 ID (Hashed, Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "분위기 트래커 ID (Path Variable)", required = true)
     })
     public ApiResponse<MoodTrackerResponseDTO.ReportResult> getMoodTrackerReportResult(
-            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable(name = "moodTrackerId") String moodTrackerId,
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(hidden = true) @AuthMoodTracker MoodTracker moodTracker
     ) {
@@ -212,16 +208,16 @@ public class MoodTrackerController {
 
     }
 
-    @GetMapping("/{mood-tracker-hashed-Id}/responses")
+    @GetMapping("/{moodTrackerId}/responses")
     @Operation(
-            summary = "분위기 트래커 설문 응답 조회 API + last opend 처리",
+            summary = "분위기 트래커 설문 응답 조회 API + last opened 처리",
             description = "# [v1.2 (2025-08-05)](https://www.notion.so/2265da7802c5808290adf17d8d4591a4) 분위기 트래커(moodTrackerId)에 대한 개별 응답 데이터를 조회합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "분위기 트래커 ID (Hashed, Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "분위기 트래커 ID (Path Variable)", required = true)
     })
     public ApiResponse<MoodTrackerResponseDTO.ResponseResult> getMoodTrackerResponseResult(
-            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable(name = "moodTrackerId") String moodTrackerId,
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(hidden = true) @AuthMoodTracker MoodTracker moodTracker
     ) {
@@ -232,16 +228,16 @@ public class MoodTrackerController {
 
     }
 
-    @GetMapping("/{mood-tracker-hashed-Id}/download")
+    @GetMapping("/{moodTrackerId}/download")
     @Operation(
             summary = "분위기 트래커 설문 리포트 다운로드 API",
             description = "# [v1.0 (2025-08-13)](https://www.notion.so/2265da7802c580e3b53ddd8d181922b1) 분위기 트래커(moodTrackerId)에 대한 개별 리포트 다운로드 링크를 조회합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "분위기 트래커 ID (Hashed, Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "분위기 트래커 ID (Path Variable)", required = true)
     })
     public ApiResponse<MoodTrackerResponseDTO.ReportDownLoadLinkResponse> downloadList(
-            @PathVariable(name = "mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable(name = "moodTrackerId") String moodTrackerId,
             @RequestParam Format format,
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(hidden = true) @AuthMoodTracker MoodTracker moodTracker
@@ -253,16 +249,16 @@ public class MoodTrackerController {
 
     }
 
-    @PostMapping("/{mood-tracker-hashed-Id}/report-test")
+    @PostMapping("/{moodTrackerId}/report-test")
     @Operation(
             summary = "분위기 트래커 설문 리포트 즉시 생성 API",
             description = "# [v1.0 (2025-07-26)](https://www.notion.so/23f5da7802c58080b4a5e6d24b47d924) 해당 ID의 분위기 트래커 설문 리포트를 즉시 생성합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "16자 분위기 트래커 ID (Path Variable)", required = true)
     })
     public  ApiResponse<Void> generateMoodTrackerReportTest (
-            @PathVariable("mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable("moodTrackerId") String moodTrackerId,
             @Parameter(hidden = true) @AuthMoodTracker MoodTracker moodTracker
     ) {
 
@@ -272,16 +268,16 @@ public class MoodTrackerController {
 
     }
 
-    @PostMapping("/{mood-tracker-hashed-Id}/report-file-thumbnail-test")
+    @PostMapping("/{moodTrackerId}/report-file-thumbnail-test")
     @Operation(
             summary = "분위기 트래커 설문 리포트, 파일, 썸네일 즉시 생성 테스트 API + redis에서 제외하여 마감일시에 중복 생성 불가",
             description = "# [v1.0 (2025-08-14)](https://www.notion.so/24f5da7802c58019a1f7d9c8e882226e) 해당 ID의 분위기 트래커 설문 리포트를 즉시 생성합니다."
     )
     @Parameters({
-            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
+            @Parameter(name = "moodTrackerId", description = "분위기 트래커 ID (Path Variable)", required = true)
     })
     public  ApiResponse<Void> generateMoodTrackerReportFileAndThumbnailTest (
-            @PathVariable("mood-tracker-hashed-Id") String moodTrackerHashedId,
+            @PathVariable("moodTrackerId") Long moodTrackerId,
             @Parameter(hidden = true) @AuthMoodTracker MoodTracker moodTracker
     ) {
 

--- a/src/main/java/com/haru/api/moodTracker/presentation/dto/MoodTrackerRequestDTO.java
+++ b/src/main/java/com/haru/api/moodTracker/presentation/dto/MoodTrackerRequestDTO.java
@@ -3,7 +3,7 @@ package com.haru.api.moodTracker.presentation.dto;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.haru.api.moodTracker.domain.enums.MoodTrackerVisibility;
 import com.haru.api.moodTracker.domain.enums.QuestionType;
-import com.haru.api.global.common.entity.DocumentModifier;
+import com.haru.api.shared_kernel.domain.DocumentModifier;
 import com.haru.api.global.util.json.ToLongDeserializer;
 import com.haru.api.global.util.json.ToLongListDeserializer;
 import io.swagger.v3.oas.annotations.media.ArraySchema;

--- a/src/main/java/com/haru/api/shared_kernel/application/port/in/DocumentQueryUseCase.java
+++ b/src/main/java/com/haru/api/shared_kernel/application/port/in/DocumentQueryUseCase.java
@@ -2,16 +2,27 @@ package com.haru.api.shared_kernel.application.port.in;
 
 import com.haru.api.shared_kernel.domain.Documentable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DocumentQueryUseCase {
 
     /**
-     * workspace에 속한 문서를 조회하는 메서드
+     * 워크스페이스에 속한 문서를 조회하는 메서드
      *
      * @param workspaceId
      * @return
      */
     List<Documentable> getDocumentsByWorkspaceId(Long workspaceId);
+
+    /**
+     * 워크스페이스에 속한 문서중에서 시작 날짜와 종료 날짜에 생성된 문서를 조회하는 메서드
+     *
+     * @param workspaceId
+     * @param startDate
+     * @param endDate
+     * @return
+     */
+    List<Documentable> getAllDocumentsForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
 
 }

--- a/src/main/java/com/haru/api/shared_kernel/application/port/in/DocumentQueryUseCase.java
+++ b/src/main/java/com/haru/api/shared_kernel/application/port/in/DocumentQueryUseCase.java
@@ -1,0 +1,17 @@
+package com.haru.api.shared_kernel.application.port.in;
+
+import com.haru.api.shared_kernel.domain.Documentable;
+
+import java.util.List;
+
+public interface DocumentQueryUseCase {
+
+    /**
+     * workspace에 속한 문서를 조회하는 메서드
+     *
+     * @param workspaceId
+     * @return
+     */
+    List<Documentable> getDocumentsByWorkspaceId(Long workspaceId);
+
+}

--- a/src/main/java/com/haru/api/shared_kernel/application/service/DocumentQueryUseCaseImpl.java
+++ b/src/main/java/com/haru/api/shared_kernel/application/service/DocumentQueryUseCaseImpl.java
@@ -8,6 +8,7 @@ import com.haru.api.snsEvent.infrastructure.SnsEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +28,18 @@ public class DocumentQueryUseCaseImpl implements DocumentQueryUseCase {
         documentList.addAll(meetingRepository.findAllByWorkspaceId(workspaceId));
         documentList.addAll(snsEventRepository.findAllByWorkspaceId(workspaceId));
         documentList.addAll(moodTrackerRepository.findAllByWorkspaceId(workspaceId));
+
+        return documentList;
+    }
+
+    @Override
+    public List<Documentable> getAllDocumentsForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate) {
+
+        List<Documentable> documentList = new ArrayList<>();
+
+        documentList.addAll(meetingRepository.findAllDocumentForCalendars(workspaceId, startDate, endDate));
+        documentList.addAll(snsEventRepository.findAllDocumentForCalendars(workspaceId, startDate, endDate));
+        documentList.addAll(moodTrackerRepository.findAllDocumentForCalendars(workspaceId, startDate, endDate));
 
         return documentList;
     }

--- a/src/main/java/com/haru/api/shared_kernel/application/service/DocumentQueryUseCaseImpl.java
+++ b/src/main/java/com/haru/api/shared_kernel/application/service/DocumentQueryUseCaseImpl.java
@@ -1,0 +1,33 @@
+package com.haru.api.shared_kernel.application.service;
+
+import com.haru.api.meeting.infrastructure.MeetingRepository;
+import com.haru.api.moodTracker.infrastructure.MoodTrackerRepository;
+import com.haru.api.shared_kernel.application.port.in.DocumentQueryUseCase;
+import com.haru.api.shared_kernel.domain.Documentable;
+import com.haru.api.snsEvent.infrastructure.SnsEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DocumentQueryUseCaseImpl implements DocumentQueryUseCase {
+
+    private final MeetingRepository meetingRepository;
+    private final SnsEventRepository snsEventRepository;
+    private final MoodTrackerRepository moodTrackerRepository;
+
+    @Override
+    public List<Documentable> getDocumentsByWorkspaceId(Long workspaceId) {
+
+        List<Documentable> documentList = new ArrayList<>();
+
+        documentList.addAll(meetingRepository.findAllByWorkspaceId(workspaceId));
+        documentList.addAll(snsEventRepository.findAllByWorkspaceId(workspaceId));
+        documentList.addAll(moodTrackerRepository.findAllByWorkspaceId(workspaceId));
+
+        return documentList;
+    }
+}

--- a/src/main/java/com/haru/api/shared_kernel/domain/DocumentModifier.java
+++ b/src/main/java/com/haru/api/shared_kernel/domain/DocumentModifier.java
@@ -1,4 +1,4 @@
-package com.haru.api.global.common.entity;
+package com.haru.api.shared_kernel.domain;
 
 public interface DocumentModifier {
     String getTitle();

--- a/src/main/java/com/haru/api/shared_kernel/domain/Documentable.java
+++ b/src/main/java/com/haru/api/shared_kernel/domain/Documentable.java
@@ -1,4 +1,4 @@
-package com.haru.api.global.common;
+package com.haru.api.shared_kernel.domain;
 
 import com.haru.api.user.domain.enums.DocumentType;
 

--- a/src/main/java/com/haru/api/shared_kernel/domain/Documentable.java
+++ b/src/main/java/com/haru/api/shared_kernel/domain/Documentable.java
@@ -2,10 +2,13 @@ package com.haru.api.shared_kernel.domain;
 
 import com.haru.api.user.domain.enums.DocumentType;
 
+import java.time.LocalDateTime;
+
 public interface Documentable {
     Long getId();
     String getTitle();
     Long getWorkspaceId();
     DocumentType getDocumentType();
     String getThumbnailKeyName();
+    LocalDateTime getCreatedAt();
 }

--- a/src/main/java/com/haru/api/snsEvent/application/service/SnsEventCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/snsEvent/application/service/SnsEventCommandUseCaseImpl.java
@@ -1,7 +1,7 @@
 package com.haru.api.snsEvent.application.service;
 
 import com.haru.api.snsEvent.application.port.in.SnsEventCommandUseCase;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import com.haru.api.snsEvent.application.converter.SnsEventConverter;
 import com.haru.api.snsEvent.presentation.dto.SnsEventRequestDTO;
 import com.haru.api.snsEvent.presentation.dto.SnsEventResponseDTO;
@@ -63,7 +63,7 @@ public class SnsEventCommandUseCaseImpl implements SnsEventCommandUseCase {
     private final ParticipantRepository participantRepository;
     private final WinnerRepository winnerRepository;
     private final RestTemplate restTemplate;
-    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
     private final InstagramOauth2RestTemplate instagramOauth2RestTemplate;
     private final int WORD_TABLE_SIZE = 40; // 페이지당 총 아이디 수
     private final int PER_COL = WORD_TABLE_SIZE/ 2; // 한쪽 컬럼에 들어갈 개수
@@ -177,7 +177,7 @@ public class SnsEventCommandUseCaseImpl implements SnsEventCommandUseCase {
         // sns event 생성 시 워크스페이스에 속해있는 모든 유저에 대해
         // last opened 테이블에 마지막으로 연 시간은 null로하여 추가
         List<User> usersInWorkspace = userWorkspaceJpaRepository.findUsersByWorkspaceId(foundWorkspace.getId());
-        userDocumentLastOpenedQueryUseCase.createInitialRecordsForWorkspaceUsers(usersInWorkspace, savedSnsEvent);
+        userDocumentLastOpenedCommandUseCase.createInitialRecordsForWorkspaceUsers(usersInWorkspace, savedSnsEvent);
 
         return SnsEventResponseDTO.CreateSnsEventResponse.builder()
                 .snsEventId(createdSnsEvent.getId())
@@ -251,7 +251,7 @@ public class SnsEventCommandUseCaseImpl implements SnsEventCommandUseCase {
 
         // SNS Event 제목 수정 시 워크스페이스에 속해있는 모든 유저에 대해 썸네일 이미지 키 수정
         List<User> usersInWorkspace = userWorkspaceJpaRepository.findUsersByWorkspaceId(savedSnsEvent.getWorkspace().getId());
-        userDocumentLastOpenedQueryUseCase.updateRecordsTitleAndThumbnailForWorkspaceUsers(savedSnsEvent, request);
+        userDocumentLastOpenedCommandUseCase.updateRecordsTitleAndThumbnailForWorkspaceUsers(savedSnsEvent, request);
     }
 
     @Override

--- a/src/main/java/com/haru/api/snsEvent/domain/SnsEvent.java
+++ b/src/main/java/com/haru/api/snsEvent/domain/SnsEvent.java
@@ -1,6 +1,6 @@
 package com.haru.api.snsEvent.domain;
 
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.enums.DocumentType;
 import com.haru.api.user.domain.User;
 import com.haru.api.workspace.domain.Workspace;

--- a/src/main/java/com/haru/api/snsEvent/presentation/dto/SnsEventRequestDTO.java
+++ b/src/main/java/com/haru/api/snsEvent/presentation/dto/SnsEventRequestDTO.java
@@ -1,6 +1,6 @@
 package com.haru.api.snsEvent.presentation.dto;
 
-import com.haru.api.global.common.entity.DocumentModifier;
+import com.haru.api.shared_kernel.domain.DocumentModifier;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/haru/api/user/application/converter/UserDocumentLastOpenedConverter.java
+++ b/src/main/java/com/haru/api/user/application/converter/UserDocumentLastOpenedConverter.java
@@ -1,6 +1,6 @@
 package com.haru.api.user.application.converter;
 
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.UserDocumentId;
 import com.haru.api.user.domain.UserDocumentLastOpened;
 import com.haru.api.user.domain.User;

--- a/src/main/java/com/haru/api/user/application/port/in/UserDocumentLastOpenedCommandUseCase.java
+++ b/src/main/java/com/haru/api/user/application/port/in/UserDocumentLastOpenedCommandUseCase.java
@@ -1,13 +1,14 @@
 package com.haru.api.user.application.port.in;
 
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.UserDocumentId;
 import com.haru.api.user.domain.User;
-import com.haru.api.global.common.entity.DocumentModifier;
+import com.haru.api.shared_kernel.domain.DocumentModifier;
+import com.haru.api.user.domain.UserDocumentLastOpened;
 
 import java.util.List;
 
-public interface UserDocumentLastOpenedQueryUseCase {
+public interface UserDocumentLastOpenedCommandUseCase {
 
     /**
      * 문서 생성 시, 워크스페이스에 속해있는 유저의 해당 문서에 대한 UserDocumentLastOpened를 생성하는 메서드
@@ -41,5 +42,12 @@ public interface UserDocumentLastOpenedQueryUseCase {
      * @param document
      */
     void deleteRecordsForWorkspaceUsers(Documentable document);
+
+    /**
+     * UserDocumentLastOpened를 한 번에 저장하는 메서드
+     *
+     * @param userDocumentLastOpenedList
+     */
+    void saveAll(List<UserDocumentLastOpened> userDocumentLastOpenedList);
 
 }

--- a/src/main/java/com/haru/api/user/application/port/in/UserDocumentLastOpenedQueryUseCase.java
+++ b/src/main/java/com/haru/api/user/application/port/in/UserDocumentLastOpenedQueryUseCase.java
@@ -1,0 +1,14 @@
+package com.haru.api.user.application.port.in;
+
+import com.haru.api.user.domain.UserDocumentLastOpened;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+public interface UserDocumentLastOpenedQueryUseCase {
+
+    List<UserDocumentLastOpened> findRecentDocumentsByTitle(Long userId, Long workspaceId, String title);
+
+    List<UserDocumentLastOpened> findRecentDocuments(Long userId, Long workspaceId, PageRequest pageRequest);
+
+}

--- a/src/main/java/com/haru/api/user/application/service/UserDocumentLastOpenedCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/user/application/service/UserDocumentLastOpenedCommandUseCaseImpl.java
@@ -2,14 +2,14 @@ package com.haru.api.user.application.service;
 
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
-import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import com.haru.api.user.application.port.out.UserDocumentLastOpenedPort;
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.application.port.out.UserPort;
 import com.haru.api.user.domain.UserDocumentId;
 import com.haru.api.user.domain.UserDocumentLastOpened;
 import com.haru.api.user.domain.User;
-import com.haru.api.global.common.entity.DocumentModifier;
+import com.haru.api.shared_kernel.domain.DocumentModifier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class UserDocumentLastOpenedQueryUseCaseImpl implements UserDocumentLastOpenedQueryUseCase {
+public class UserDocumentLastOpenedCommandUseCaseImpl implements UserDocumentLastOpenedCommandUseCase {
 
     private final UserDocumentLastOpenedPort userDocumentLastOpenedPort;
     private final UserPort userPort;
@@ -103,6 +103,11 @@ public class UserDocumentLastOpenedQueryUseCaseImpl implements UserDocumentLastO
             userDocumentLastOpenedPort.deleteAll(recordsToUpdate);
         }
 
+    }
+
+    @Override
+    public void saveAll(List<UserDocumentLastOpened> userDocumentLastOpenedList) {
+        userDocumentLastOpenedPort.saveAll(userDocumentLastOpenedList);
     }
 
 }

--- a/src/main/java/com/haru/api/user/application/service/UserDocumentLastOpenedQueryUseCaseImpl.java
+++ b/src/main/java/com/haru/api/user/application/service/UserDocumentLastOpenedQueryUseCaseImpl.java
@@ -1,0 +1,27 @@
+package com.haru.api.user.application.service;
+
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
+import com.haru.api.user.application.port.out.UserDocumentLastOpenedPort;
+import com.haru.api.user.domain.UserDocumentLastOpened;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserDocumentLastOpenedQueryUseCaseImpl implements UserDocumentLastOpenedQueryUseCase {
+
+    private final UserDocumentLastOpenedPort userDocumentLastOpenedPort;
+
+    @Override
+    public List<UserDocumentLastOpened> findRecentDocumentsByTitle(Long userId, Long workspaceId, String title) {
+        return userDocumentLastOpenedPort.findRecentDocumentsByTitle(userId, workspaceId, title);
+    }
+
+    @Override
+    public List<UserDocumentLastOpened> findRecentDocuments(Long userId, Long workspaceId, PageRequest pageRequest) {
+        return userDocumentLastOpenedPort.findRecentDocuments(userId, workspaceId, pageRequest);
+    }
+}

--- a/src/main/java/com/haru/api/user/domain/UserDocumentLastOpened.java
+++ b/src/main/java/com/haru/api/user/domain/UserDocumentLastOpened.java
@@ -1,6 +1,6 @@
 package com.haru.api.user.domain;
 
-import com.haru.api.global.common.entity.DocumentModifier;
+import com.haru.api.shared_kernel.domain.DocumentModifier;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;

--- a/src/main/java/com/haru/api/workspace/application/converter/WorkspaceConverter.java
+++ b/src/main/java/com/haru/api/workspace/application/converter/WorkspaceConverter.java
@@ -1,28 +1,14 @@
 package com.haru.api.workspace.application.converter;
 
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.UserDocumentLastOpened;
-import com.haru.api.user.domain.enums.DocumentType;
-import com.haru.api.meeting.domain.Meeting;
-import com.haru.api.moodTracker.domain.MoodTracker;
-import com.haru.api.snsEvent.domain.SnsEvent;
 import com.haru.api.user.presentation.dto.UserResponseDTO;
 import com.haru.api.workspace.presentation.dto.WorkspaceResponseDTO;
 import com.haru.api.workspace.domain.Workspace;
-import com.haru.api.global.util.HashIdUtil;
-import com.haru.api.infra.s3.AmazonS3Manager;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Component
-@RequiredArgsConstructor
 public class WorkspaceConverter {
-
-    private final HashIdUtil hashIdUtil;
-    private final AmazonS3Manager s3Manager;
 
     public static WorkspaceResponseDTO.Workspace toWorkspaceDTO(Workspace workspace, String presignedUrl) {
         return WorkspaceResponseDTO.Workspace.builder()
@@ -32,16 +18,9 @@ public class WorkspaceConverter {
                 .build();
     }
 
-    public WorkspaceResponseDTO.Document toDocument(UserDocumentLastOpened document) {
-        String documentId;
-        if (DocumentType.TEAM_MOOD_TRACKER.equals(document.getId().getDocumentType())) {
-            documentId = hashIdUtil.encode(document.getId().getDocumentId());
-        } else {
-            documentId = String.valueOf(document.getId().getDocumentId());
-        }
-
+    public static WorkspaceResponseDTO.Document toDocument(UserDocumentLastOpened document) {
         return WorkspaceResponseDTO.Document.builder()
-                .documentId(documentId)
+                .documentId(document.getId().getDocumentId())
                 .title(document.getTitle())
                 .documentType(document.getId().getDocumentType())
                 .lastOpened(document.getLastOpened())
@@ -62,16 +41,9 @@ public class WorkspaceConverter {
                 .build();
     }
 
-    public WorkspaceResponseDTO.DocumentSidebar toDocumentSidebar(UserDocumentLastOpened document) {
-        String documentId;
-        if (DocumentType.TEAM_MOOD_TRACKER.equals(document.getId().getDocumentType())) {
-            documentId = hashIdUtil.encode(document.getId().getDocumentId());
-        } else {
-            documentId = String.valueOf(document.getId().getDocumentId());
-        }
-
+    public static WorkspaceResponseDTO.DocumentSidebar toDocumentSidebar(UserDocumentLastOpened document) {
         return WorkspaceResponseDTO.DocumentSidebar.builder()
-                .documentId(documentId)
+                .documentId(document.getId().getDocumentId())
                 .documentType(document.getId().getDocumentType())
                 .title(document.getTitle())
                 .build();
@@ -83,59 +55,23 @@ public class WorkspaceConverter {
                 .build();
     }
 
-    // Meeting 엔티티 리스트를 DocumentCalendar DTO 리스트로 변환
-    public List<WorkspaceResponseDTO.DocumentCalendar> toDocumentCalendarListFromMeeting(List<Meeting> meetingList) {
-        return meetingList.stream()
-                .map(meeting -> WorkspaceResponseDTO.DocumentCalendar.builder()
-                        .documentId(String.valueOf(meeting.getId()))
-                        .title(meeting.getTitle())
-                        .documentType(DocumentType.AI_MEETING_MANAGER)
-                        .createdAt(meeting.getCreatedAt())
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    // SnsEvent 엔티티 리스트를 DocumentCalendar DTO 리스트로 변환
-    public List<WorkspaceResponseDTO.DocumentCalendar> toDocumentCalendarListFromSnsEvent(List<SnsEvent> snsEventList) {
-        return snsEventList.stream()
-                .map(snsEvent -> WorkspaceResponseDTO.DocumentCalendar.builder()
-                        .documentId(String.valueOf(snsEvent.getId()))
-                        .title(snsEvent.getTitle())
-                        .documentType(DocumentType.SNS_EVENT_ASSISTANT)
-                        .createdAt(snsEvent.getCreatedAt())
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    // MoodTracker 엔티티 리스트를 DocumentCalendar DTO 리스트로 변환
-    public List<WorkspaceResponseDTO.DocumentCalendar> toDocumentCalendarListFromMoodTracker(List<MoodTracker> moodTrackerList) {
-        return moodTrackerList.stream()
-                .map(moodTracker -> WorkspaceResponseDTO.DocumentCalendar.builder()
-                        .documentId(hashIdUtil.encode(moodTracker.getId())) // MoodTracker는 hashid로 변환
-                        .title(moodTracker.getTitle())
-                        .documentType(DocumentType.TEAM_MOOD_TRACKER)
-                        .createdAt(moodTracker.getCreatedAt())
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    // 모든 문서 리스트를 합쳐 최종 DTO로 반환하는 통합 메서드
-    public WorkspaceResponseDTO.DocumentCalendarList toDocumentCalendarList(
-            List<Meeting> meetingList,
-            List<SnsEvent> snsEventList,
-            List<MoodTracker> moodTrackerList) {
-
-        List<WorkspaceResponseDTO.DocumentCalendar> allResults = new ArrayList<>();
-        allResults.addAll(toDocumentCalendarListFromMeeting(meetingList));
-        allResults.addAll(toDocumentCalendarListFromSnsEvent(snsEventList));
-        allResults.addAll(toDocumentCalendarListFromMoodTracker(moodTrackerList));
-
-        return WorkspaceResponseDTO.DocumentCalendarList.builder()
-                .documentList(allResults)
+    public static WorkspaceResponseDTO.DocumentCalendar toDocumentCalender(Documentable document) {
+        return WorkspaceResponseDTO.DocumentCalendar.builder()
+                .documentId(document.getId())
+                .title(document.getTitle())
+                .documentType(document.getDocumentType())
+                .createdAt(document.getCreatedAt())
                 .build();
     }
 
-    public WorkspaceResponseDTO.WorkspaceEditPage toWorkspaceEditPage(Workspace workspace, List<UserResponseDTO.MemberInfo> memberInfoList, String imageUrl) {
+    public static WorkspaceResponseDTO.DocumentCalendarList toDocumentCalendarList(
+            List<WorkspaceResponseDTO.DocumentCalendar> documentCalendarList) {
+        return WorkspaceResponseDTO.DocumentCalendarList.builder()
+                .documentList(documentCalendarList)
+                .build();
+    }
+
+    public static WorkspaceResponseDTO.WorkspaceEditPage toWorkspaceEditPage(Workspace workspace, List<UserResponseDTO.MemberInfo> memberInfoList, String imageUrl) {
         return WorkspaceResponseDTO.WorkspaceEditPage.builder()
                 .title(workspace.getTitle())
                 .imageUrl(imageUrl)
@@ -143,19 +79,9 @@ public class WorkspaceConverter {
                 .build();
     }
 
-    public WorkspaceResponseDTO.RecentDocument toRecentDocument(UserDocumentLastOpened userDocumentLastOpened) {
-        String thumbnailUrl = s3Manager.generatePresignedUrl(userDocumentLastOpened.getThumbnailKeyName());
-
-        String documentId;
-
-        if(userDocumentLastOpened.getId().getDocumentType().equals(DocumentType.TEAM_MOOD_TRACKER)) {
-            documentId = hashIdUtil.encode(userDocumentLastOpened.getId().getDocumentId());
-        } else {
-            documentId = String.valueOf(userDocumentLastOpened.getId().getDocumentId());
-        }
-
+    public static WorkspaceResponseDTO.RecentDocument toRecentDocument(UserDocumentLastOpened userDocumentLastOpened, String thumbnailUrl) {
         return WorkspaceResponseDTO.RecentDocument.builder()
-                .documentId(documentId)
+                .documentId(userDocumentLastOpened.getId().getDocumentId())
                 .title(userDocumentLastOpened.getTitle())
                 .documentType(userDocumentLastOpened.getId().getDocumentType())
                 .thumbnailUrl(thumbnailUrl)
@@ -163,7 +89,7 @@ public class WorkspaceConverter {
                 .build();
     }
 
-    public WorkspaceResponseDTO.RecentDocumentList toRecentDocumentList(List<WorkspaceResponseDTO.RecentDocument> recentDocumentList) {
+    public static WorkspaceResponseDTO.RecentDocumentList toRecentDocumentList(List<WorkspaceResponseDTO.RecentDocument> recentDocumentList) {
         return WorkspaceResponseDTO.RecentDocumentList.builder()
                 .documents(recentDocumentList)
                 .build();

--- a/src/main/java/com/haru/api/workspace/application/port/in/WorkspaceCommandUseCase.java
+++ b/src/main/java/com/haru/api/workspace/application/port/in/WorkspaceCommandUseCase.java
@@ -8,13 +8,48 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface WorkspaceCommandUseCase {
 
+    /**
+     * workspace 생성 메서드
+     *
+     * @param user
+     * @param request
+     * @param image
+     * @return
+     */
     WorkspaceResponseDTO.Workspace createWorkspace(User user, WorkspaceRequestDTO.WorkspaceCreateRequest request, MultipartFile image);
 
+    /**
+     * workspace 제목 수정 메서드
+     *
+     * @param user
+     * @param workspace
+     * @param request
+     * @param image
+     * @return
+     */
     WorkspaceResponseDTO.Workspace updateWorkspace(User user, Workspace workspace, WorkspaceRequestDTO.WorkspaceUpdateRequest request, MultipartFile image);
 
+    /**
+     * 워크스페이스 초대 메일 클릭 시 호출되는 초대 수락 메서드
+     *
+     * @param token
+     * @return
+     */
     WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String token);
 
+    /**
+     * 회원가입 시 토큰이 있는 경우 호출되는 초대 수락 메서드
+     *
+     * @param token
+     * @param user
+     */
     void acceptInvite(String token, User user);
 
+    /**
+     * 워크스페이스 초대 메일을 보내는 메서드
+     *
+     * @param user
+     * @param request
+     */
     void sendInviteEmail(User user, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request);
 }

--- a/src/main/java/com/haru/api/workspace/application/port/in/WorkspaceQueryUseCase.java
+++ b/src/main/java/com/haru/api/workspace/application/port/in/WorkspaceQueryUseCase.java
@@ -8,13 +8,51 @@ import java.time.LocalDate;
 
 public interface WorkspaceQueryUseCase {
 
-    WorkspaceResponseDTO.DocumentList getDocuments(User user, Workspace workspace, String title);
+    /**
+     * 제목으로 워크스페이스에 속해있는 문서를 검색하는 메서드
+     *
+     * @param user
+     * @param workspace
+     * @param title
+     * @return
+     */
+    WorkspaceResponseDTO.DocumentList getDocumentsByTitle(User user, Workspace workspace, String title);
 
-    WorkspaceResponseDTO.DocumentSidebarList getDocumentWithoutLastOpenedList(User user, Workspace workspace);
+    /**
+     * 사이드바에 최신문서를 보여주기 위해 조회하는 메서드
+     *
+     * @param user
+     * @param workspace
+     * @return
+     */
+    WorkspaceResponseDTO.DocumentSidebarList getDocumentsForSidebar(User user, Workspace workspace);
 
+    /**
+     * 캘린더에 문서를 보여주기 위한 메서드
+     *
+     * @param user
+     * @param workspace
+     * @param startDate
+     * @param endDate
+     * @return
+     */
     WorkspaceResponseDTO.DocumentCalendarList getDocumentForCalendar(User user, Workspace workspace, LocalDate startDate, LocalDate endDate);
 
+    /**
+     * 워크스페이스 수정 페이지 조회를 위한 메서드
+     *
+     * @param user
+     * @param workspace
+     * @return
+     */
     WorkspaceResponseDTO.WorkspaceEditPage getEditPage(User user, Workspace workspace);
 
+    /**
+     * 메인페이지에 최근 문서를 보여주기 위한 메서드
+     *
+     * @param user
+     * @param workspace
+     * @return
+     */
     WorkspaceResponseDTO.RecentDocumentList getRecentDocuments(User user, Workspace workspace);
 }

--- a/src/main/java/com/haru/api/workspace/application/service/WorkspaceCommandUseCaseImpl.java
+++ b/src/main/java/com/haru/api/workspace/application/service/WorkspaceCommandUseCaseImpl.java
@@ -1,17 +1,15 @@
 package com.haru.api.workspace.application.service;
 
+import com.haru.api.shared_kernel.application.port.in.DocumentQueryUseCase;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedCommandUseCase;
 import com.haru.api.user.application.port.in.UserQueryUseCase;
 import com.haru.api.user.application.converter.UserDocumentLastOpenedConverter;
 import com.haru.api.workspace.application.port.in.WorkspaceCommandUseCase;
-import com.haru.api.user.application.port.out.UserDocumentLastOpenedPort;
 import com.haru.api.workspace.application.port.out.UserWorkspacePort;
 import com.haru.api.workspace.application.port.out.WorkspaceInvitationPort;
 import com.haru.api.workspace.application.port.out.WorkspacePort;
-import com.haru.api.global.common.Documentable;
+import com.haru.api.shared_kernel.domain.Documentable;
 import com.haru.api.user.domain.UserDocumentLastOpened;
-import com.haru.api.meeting.infrastructure.MeetingRepository;
-import com.haru.api.moodTracker.infrastructure.MoodTrackerRepository;
-import com.haru.api.snsEvent.infrastructure.SnsEventRepository;
 import com.haru.api.user.domain.User;
 import com.haru.api.workspace.domain.enums.Auth;
 import com.haru.api.workspace.domain.UserWorkspace;
@@ -42,18 +40,14 @@ import java.util.UUID;
 public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
 
     private final UserQueryUseCase userQueryUseCase;
+    private final UserDocumentLastOpenedCommandUseCase userDocumentLastOpenedCommandUseCase;
+    private final DocumentQueryUseCase documentQueryUseCase;
 
     private final WorkspacePort workspacePort;
     private final UserWorkspacePort userWorkspacePort;
     private final WorkspaceInvitationPort workspaceInvitationPort;
-    private final UserDocumentLastOpenedPort userDocumentLastOpenedPort;
-
-    private final MeetingRepository meetingRepository;
-    private final SnsEventRepository snsEventRepository;
-    private final MoodTrackerRepository moodTrackerRepository;
 
     private final AmazonS3Manager amazonS3Manager;
-
     private final EmailSender emailSender;
 
     @Value("${invite-url}")
@@ -117,7 +111,6 @@ public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
         return WorkspaceConverter.toWorkspaceDTO(workspace, amazonS3Manager.generatePresignedUrl(workspace.getKeyName()));
     }
 
-    // 초대 메일 클릭 시 호출되는 메서드
     @Override
     @Transactional
     public WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String token) {
@@ -125,8 +118,7 @@ public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
         WorkspaceInvitation foundWorkspaceInvitation = workspaceInvitationPort.findByToken(token)
                 .orElseThrow(() -> new WorkspaceInvitationHandler(ErrorStatus.INVITATION_NOT_FOUND));
 
-        Workspace foundWorkspace = workspacePort.findById(foundWorkspaceInvitation.getWorkspace().getId())
-                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
+        Workspace foundWorkspace = foundWorkspaceInvitation.getWorkspace();
 
         // 이미 수락된 초대장이면 예외 발생
         if(foundWorkspaceInvitation.isAccepted())
@@ -141,6 +133,7 @@ public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
         if(isAlreadyRegistered) {
             // 초대장을 수락했다고 db에 저장
             foundWorkspaceInvitation.setAccepted();
+            workspaceInvitationPort.save(foundWorkspaceInvitation);
         } else {
             // 가입되지 않은 사용자면 not success
             return WorkspaceConverter.toInvitationAcceptResult(false, false, foundWorkspace);
@@ -151,15 +144,13 @@ public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
         return WorkspaceConverter.toInvitationAcceptResult(true, true, foundWorkspace);
     }
 
-    // 회원가입 시 초대 토큰이 있는 경우 호출
     @Transactional
     @Override
     public void acceptInvite(String token, User signedUser) {
         WorkspaceInvitation foundWorkspaceInvitation = workspaceInvitationPort.findByToken(token)
                 .orElseThrow(() -> new WorkspaceInvitationHandler(ErrorStatus.INVITATION_NOT_FOUND));
 
-        Workspace foundWorkspace = workspacePort.findById(foundWorkspaceInvitation.getWorkspace().getId())
-                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
+        Workspace foundWorkspace = foundWorkspaceInvitation.getWorkspace();
 
         if(foundWorkspaceInvitation.isAccepted())
             throw new WorkspaceInvitationHandler(ErrorStatus.ALREADY_ACCEPTED);
@@ -173,17 +164,15 @@ public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
     @Transactional
     @Override
     public void sendInviteEmail(User user, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request) {
-        Long workspaceId = request.getWorkspaceId();
-        List<String> emails = request.getEmails();
 
-        Workspace foundWorkspace = workspacePort.findById(workspaceId)
+        Workspace foundWorkspace = workspacePort.findById(request.getWorkspaceId())
                 .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
 
         userWorkspacePort.findByUserIdAndWorkspaceId(user.getId(), foundWorkspace.getId())
                 .orElseThrow(() -> new UserWorkspaceHandler(ErrorStatus.USER_WORKSPACE_NOT_FOUND));
 
         // 이메일마다 invitation 생성하여 저장, 초대 수락 토큰 생성, 초대 이메일 발송
-        for(String email: emails) {
+        for(String email: request.getEmails()) {
             String token = UUID.randomUUID().toString();
 
             WorkspaceInvitation workspaceInvitation = WorkspaceInvitation.builder()
@@ -213,28 +202,14 @@ public class WorkspaceCommandUseCaseImpl implements WorkspaceCommandUseCase {
                 .auth(Auth.MEMBER)
                 .build());
 
-        // 문서 목록을 UserDocumentLastOpened에 추가
-        List<UserDocumentLastOpened> userDocumentLastOpenedList = addDocumentsToUserLastOpened(workspace, user);
-        if (!userDocumentLastOpenedList.isEmpty()) {
-            userDocumentLastOpenedPort.saveAll(userDocumentLastOpenedList);
-        }
-    }
-
-    private List<UserDocumentLastOpened> addDocumentsToUserLastOpened(Workspace workspace, User user) {
-
-        List<Documentable> documentList = new ArrayList<>();
-
-        documentList.addAll(meetingRepository.findAllByWorkspaceId(workspace.getId()));
-        documentList.addAll(snsEventRepository.findAllByWorkspaceId(workspace.getId()));
-        documentList.addAll(moodTrackerRepository.findAllByWorkspaceId(workspace.getId()));
+        // 워크스페이스에 속한 문서를 유저의 UserDocumentLastOpened에 추가
+        List<Documentable> documentList = documentQueryUseCase.getDocumentsByWorkspaceId(workspace.getId());
 
         List<UserDocumentLastOpened> userDocumentLastOpenedList = new ArrayList<>();
         for(Documentable documentable : documentList)
             userDocumentLastOpenedList.add(UserDocumentLastOpenedConverter.toUserDocumentLastOpened(documentable, user));
 
-        userDocumentLastOpenedPort.saveAll(userDocumentLastOpenedList);
-
-        return userDocumentLastOpenedList;
+        userDocumentLastOpenedCommandUseCase.saveAll(userDocumentLastOpenedList);
     }
 
     private String generateInvitationEmailContentHtml(String invitedEmail, String inviterName, String workspaceName, String invitationLink) {

--- a/src/main/java/com/haru/api/workspace/application/service/WorkspaceQueryUseCaseImpl.java
+++ b/src/main/java/com/haru/api/workspace/application/service/WorkspaceQueryUseCaseImpl.java
@@ -1,18 +1,14 @@
 package com.haru.api.workspace.application.service;
 
+import com.haru.api.shared_kernel.application.port.in.DocumentQueryUseCase;
+import com.haru.api.shared_kernel.domain.Documentable;
+import com.haru.api.user.application.port.in.UserDocumentLastOpenedQueryUseCase;
 import com.haru.api.workspace.application.port.in.WorkspaceQueryUseCase;
 import com.haru.api.user.domain.UserDocumentLastOpened;
-import com.haru.api.user.infrastructure.jpa.UserDocumentLastOpenedJpaRepository;
-import com.haru.api.meeting.domain.Meeting;
-import com.haru.api.meeting.infrastructure.MeetingRepository;
-import com.haru.api.moodTracker.domain.MoodTracker;
-import com.haru.api.moodTracker.infrastructure.MoodTrackerRepository;
-import com.haru.api.snsEvent.domain.SnsEvent;
-import com.haru.api.snsEvent.infrastructure.SnsEventRepository;
 import com.haru.api.user.application.converter.UserConverter;
 import com.haru.api.user.presentation.dto.UserResponseDTO;
 import com.haru.api.user.domain.User;
-import com.haru.api.workspace.infrastructure.jpa.UserWorkspaceJpaRepository;
+import com.haru.api.workspace.application.port.out.UserWorkspacePort;
 import com.haru.api.workspace.application.converter.WorkspaceConverter;
 import com.haru.api.workspace.presentation.dto.WorkspaceResponseDTO;
 import com.haru.api.workspace.domain.Workspace;
@@ -32,35 +28,34 @@ import java.util.*;
 @Transactional(readOnly = true)
 public class WorkspaceQueryUseCaseImpl implements WorkspaceQueryUseCase {
 
-    private final MeetingRepository meetingRepository;
-    private final SnsEventRepository snsEventRepository;
-    private final MoodTrackerRepository moodTrackerRepository;
-    private final UserWorkspaceJpaRepository userWorkspaceJpaRepository;
-    private final UserDocumentLastOpenedJpaRepository userDocumentLastOpenedJpaRepository;
-    private final WorkspaceConverter workspaceConverter;
+    private final UserWorkspacePort userWorkspacePort;
+
+    private final DocumentQueryUseCase documentQueryUseCase;
+    private final UserDocumentLastOpenedQueryUseCase userDocumentLastOpenedQueryUseCase;
+
     private final AmazonS3Manager amazonS3Manager;
 
     @Override
-    public WorkspaceResponseDTO.DocumentList getDocuments(User user, Workspace workspace, String title) {
+    public WorkspaceResponseDTO.DocumentList getDocumentsByTitle(User user, Workspace workspace, String title) {
 
-        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedJpaRepository.findRecentDocumentsByTitle(user.getId(), workspace.getId(), title);
+        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedQueryUseCase.findRecentDocumentsByTitle(user.getId(), workspace.getId(), title);
 
         return WorkspaceConverter.toDocumentList(
                 documentList.stream()
-                        .map(workspaceConverter::toDocument)
+                        .map(WorkspaceConverter::toDocument)
                         .toList()
         );
     }
 
     @Override
-    public WorkspaceResponseDTO.DocumentSidebarList getDocumentWithoutLastOpenedList(User user, Workspace workspace) {
+    public WorkspaceResponseDTO.DocumentSidebarList getDocumentsForSidebar(User user, Workspace workspace) {
 
         // 유저가 가장 최근에 조회한 문서 5개 추출
-        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedJpaRepository.findRecentDocuments(user.getId(), workspace.getId(), PageRequest.of(0,8));
+        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedQueryUseCase.findRecentDocuments(user.getId(), workspace.getId(), PageRequest.of(0,5));
 
         return WorkspaceConverter.toDocumentSidebarList(
                 documentList.stream()
-                        .map(workspaceConverter::toDocumentSidebar)
+                        .map(WorkspaceConverter::toDocumentSidebar)
                         .toList()
         );
     }
@@ -72,34 +67,38 @@ public class WorkspaceQueryUseCaseImpl implements WorkspaceQueryUseCase {
         LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
 
         // 워크스페이스에 속하면서 생성 날짜가 startDate, endDate 사이인 문서 리스트 검색
-        List<Meeting> meetingList = meetingRepository.findAllDocumentForCalendars(workspace.getId(), startDateTime, endDateTime);
-        List<SnsEvent> snsEventList = snsEventRepository.findAllDocumentForCalendars(workspace.getId(), startDateTime, endDateTime);
-        List<MoodTracker> moodTrackerList = moodTrackerRepository.findAllDocumentForCalendars(workspace.getId(), startDateTime, endDateTime);
+        List<Documentable> documentList = documentQueryUseCase.getAllDocumentsForCalendars(workspace.getId(), startDateTime, endDateTime);
 
         // 모든 문서 합치기
-        return workspaceConverter.toDocumentCalendarList(meetingList, snsEventList, moodTrackerList);
+        return WorkspaceConverter.toDocumentCalendarList(
+                documentList.stream()
+                        .map(WorkspaceConverter::toDocumentCalender)
+                        .toList());
     }
 
     @Override
     public WorkspaceResponseDTO.WorkspaceEditPage getEditPage(User user, Workspace workspace) {
 
-        List<UserResponseDTO.MemberInfo> memberInfoList = userWorkspaceJpaRepository.findUsersByWorkspaceId(workspace.getId()).stream()
+        List<UserResponseDTO.MemberInfo> memberInfoList = userWorkspacePort.findUsersByWorkspaceId(workspace.getId()).stream()
                 .map(UserConverter::toMemberInfo)
                 .toList();
 
         String imageUrl = amazonS3Manager.generatePresignedUrl(workspace.getKeyName());
 
-        return workspaceConverter.toWorkspaceEditPage(workspace, memberInfoList, imageUrl);
+        return WorkspaceConverter.toWorkspaceEditPage(workspace, memberInfoList, imageUrl);
     }
 
     @Override
     public WorkspaceResponseDTO.RecentDocumentList getRecentDocuments(User user, Workspace workspace) {
 
-        List<UserDocumentLastOpened> recentDocumentList = userDocumentLastOpenedJpaRepository.findRecentDocuments(user.getId(), workspace.getId(), PageRequest.of(0,8));
+        List<UserDocumentLastOpened> recentDocumentList = userDocumentLastOpenedQueryUseCase.findRecentDocuments(user.getId(), workspace.getId(), PageRequest.of(0,8));
 
-        return workspaceConverter.toRecentDocumentList(
+        return WorkspaceConverter.toRecentDocumentList(
                 recentDocumentList.stream()
-                        .map(workspaceConverter::toRecentDocument)
+                        .map(recentDocument -> {
+                            String presignedUrl = amazonS3Manager.generatePresignedUrl(recentDocument.getThumbnailKeyName());
+                            return WorkspaceConverter.toRecentDocument(recentDocument, presignedUrl);
+                        })
                         .toList()
         );
 

--- a/src/main/java/com/haru/api/workspace/presentation/WorkspaceController.java
+++ b/src/main/java/com/haru/api/workspace/presentation/WorkspaceController.java
@@ -123,7 +123,7 @@ public class WorkspaceController {
             @Parameter(hidden = true) @AuthWorkspace Workspace workspace
 
     ) {
-        WorkspaceResponseDTO.DocumentList documentList = workspaceQueryUseCase.getDocuments(user, workspace, title);
+        WorkspaceResponseDTO.DocumentList documentList = workspaceQueryUseCase.getDocumentsByTitle(user, workspace, title);
 
         return ApiResponse.onSuccess(documentList);
     }
@@ -153,7 +153,7 @@ public class WorkspaceController {
             @Parameter(hidden = true) @AuthUser User user,
             @Parameter(hidden = true) @AuthWorkspace Workspace workspace
     ) {
-        WorkspaceResponseDTO.DocumentSidebarList documentSidebarList = workspaceQueryUseCase.getDocumentWithoutLastOpenedList(user, workspace);
+        WorkspaceResponseDTO.DocumentSidebarList documentSidebarList = workspaceQueryUseCase.getDocumentsForSidebar(user, workspace);
 
         return ApiResponse.onSuccess(documentSidebarList);
     }

--- a/src/main/java/com/haru/api/workspace/presentation/dto/WorkspaceResponseDTO.java
+++ b/src/main/java/com/haru/api/workspace/presentation/dto/WorkspaceResponseDTO.java
@@ -25,7 +25,8 @@ public class WorkspaceResponseDTO {
     @Getter
     @Builder
     public static class Document {
-        private String documentId;
+        @JsonSerialize(using = ToStringSerializer.class)
+        private Long documentId;
         private String title;
         private DocumentType documentType;
         private LocalDateTime lastOpened;
@@ -40,16 +41,17 @@ public class WorkspaceResponseDTO {
     @Getter
     @Builder
     public static class InvitationAcceptResult {
-        private boolean isSuccess;
-        private boolean isAlreadyRegistered;
         @JsonSerialize(using = ToStringSerializer.class)
         private Long workspaceId;
+        private boolean isSuccess;
+        private boolean isAlreadyRegistered;
     }
 
     @Getter
     @Builder
     public static class DocumentSidebar {
-        private String documentId;
+        @JsonSerialize(using = ToStringSerializer.class)
+        private Long documentId;
         private String title;
         private DocumentType documentType;
     }
@@ -63,7 +65,8 @@ public class WorkspaceResponseDTO {
     @Getter
     @Builder
     public static class DocumentCalendar {
-        private String documentId;
+        @JsonSerialize(using = ToStringSerializer.class)
+        private Long documentId;
         private String title;
         private DocumentType documentType;
         @JsonFormat(pattern = "yyyy-MM-dd")
@@ -93,7 +96,9 @@ public class WorkspaceResponseDTO {
     @Getter
     @Builder
     public static class RecentDocument {
-        private String documentId;
+        @JsonSerialize(using = ToStringSerializer.class)
+        private Long workspaceId;
+        private Long documentId;
         private String title;
         private DocumentType documentType;
         private String thumbnailUrl;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #49

## 📝작업 내용
> workspace 리팩토링

## 🔎코드 설명(스크린샷(선택))
- Documentable, DocumentModifier를 shared_kernel로 이동
- DocumentQueryUseCase 인터페이스를 정의하여 문서와 관련된 use case를 분리
- Documentable에 getCreatedAt() 메서드 추가
- DocumentQueryUseCase 인터페이스 선언 및 구현
- UserDocumentLastOpenedQueryUseCase 선언 및 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X